### PR TITLE
Fill out Level 2 spec

### DIFF
--- a/level2.html
+++ b/level2.html
@@ -1214,7 +1214,7 @@ Possible extra rowspan handling
 </style>
   <meta content="Bikeshed version a3b64e58e069c2e8a9ffcadffb76601231663a47" name="generator">
   <link href="https://w3c.github.io/webappsec-mixed-content/level2.html" rel="canonical">
-  <meta content="e8dc9b6bc4a4cd45fcf6193c954b757beca335b6" name="document-revision">
+  <meta content="ba231f96df766bbb28908883799e400081e2578f" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -1254,6 +1254,43 @@ figcaption {
 figcaption:not(.no-marker)::before {
     content: "Figure " counter(figure) " ";
 }</style>
+<style>/* style-dfn-panel */
+
+.dfn-panel {
+    position: absolute;
+    z-index: 35;
+    height: auto;
+    width: -webkit-fit-content;
+    width: fit-content;
+    max-width: 300px;
+    max-height: 500px;
+    overflow: auto;
+    padding: 0.5em 0.75em;
+    font: small Helvetica Neue, sans-serif, Droid Sans Fallback;
+    background: #DDDDDD;
+    color: black;
+    border: outset 0.2em;
+}
+.dfn-panel:not(.on) { display: none; }
+.dfn-panel * { margin: 0; padding: 0; text-indent: 0; }
+.dfn-panel > b { display: block; }
+.dfn-panel a { color: black; }
+.dfn-panel a:not(:hover) { text-decoration: none !important; border-bottom: none !important; }
+.dfn-panel > b + b { margin-top: 0.25em; }
+.dfn-panel ul { padding: 0; }
+.dfn-panel li { list-style: inside; }
+.dfn-panel.activated {
+    display: inline-block;
+    position: fixed;
+    left: .5em;
+    bottom: 2em;
+    margin: 0 auto;
+    max-width: calc(100vw - 1.5em - .4em - .5em);
+    max-height: 30vh;
+}
+
+.dfn-paneled { cursor: pointer; }
+</style>
 <style>/* style-selflinks */
 
 .heading, .issue, .note, .example, li, dt {
@@ -1366,7 +1403,7 @@ pre .property::before, pre .property::after {
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1>Mixed Content Level 2</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2019-07-17">17 July 2019</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2019-08-20">20 August 2019</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1427,8 +1464,16 @@ pre .property::before, pre .property::after {
       <li><a href="#upgrade-algorithm"><span class="secno">3.1</span> <span class="content">Upgrade <var>request</var> to an <i lang="la">a priori</i> authenticated URL as mixed content, if appropriate</span></a>
       <li><a href="#modifications"><span class="secno">3.2</span> <span class="content">Modifications to existing algorithms</span></a>
      </ol>
-    <li><a href="#integration"><span class="secno">4</span> <span class="content">Integrations</span></a>
-    <li><a href="#obsolescences"><span class="secno">5</span> <span class="content">Obsolescences</span></a>
+    <li>
+     <a href="#integration"><span class="secno">4</span> <span class="content">Integrations</span></a>
+     <ol class="toc">
+      <li><a href="#fetch"><span class="secno">4.1</span> <span class="content">Modifications to Fetch</span></a>
+     </ol>
+    <li>
+     <a href="#obsolescences"><span class="secno">5</span> <span class="content">Obsolescences</span></a>
+     <ol class="toc">
+      <li><a href="#block-all-mixed-content"><span class="secno">5.1</span> <span class="content"><code>block-all-mixed-content</code></span></a>
+     </ol>
     <li><a href="#security-considerations"><span class="secno">6</span> <span class="content">Security and Privacy Considerations</span></a>
     <li><a href="#acknowledgements"><span class="secno">7</span> <span class="content">Acknowledgements</span></a>
     <li>
@@ -1438,9 +1483,15 @@ pre .property::before, pre .property::after {
       <li><a href="#conformant-algorithms"><span class="secno"></span> <span class="content">Conformant Algorithms</span></a>
      </ol>
     <li>
+     <a href="#index"><span class="secno"></span> <span class="content">Index</span></a>
+     <ol class="toc">
+      <li><a href="#index-defined-elsewhere"><span class="secno"></span> <span class="content">Terms defined by reference</span></a>
+     </ol>
+    <li>
      <a href="#references"><span class="secno"></span> <span class="content">References</span></a>
      <ol class="toc">
       <li><a href="#normative"><span class="secno"></span> <span class="content">Normative References</span></a>
+      <li><a href="#informative"><span class="secno"></span> <span class="content">Informative References</span></a>
      </ol>
    </ol>
   </nav>
@@ -1478,22 +1529,55 @@ pre .property::before, pre .property::after {
     <h2 class="heading settled" data-level="3" id="algorithms"><span class="secno">3. </span><span class="content">Algorithms</span><a class="self-link" href="#algorithms"></a></h2>
     <section>
      <h3 class="heading settled" data-level="3.1" id="upgrade-algorithm"><span class="secno">3.1. </span><span class="content">Upgrade <var>request</var> to an <i lang="la">a priori</i> authenticated URL as mixed content, if appropriate</span><a class="self-link" href="#upgrade-algorithm"></a></h3>
-     <p>TODO. This algorithm is called from Fetch before blocking requests as mixed content. It checks if the request is optionally-blockable mixed content, and if so rewrites the scheme to HTTPS.</p>
+     <p class="note" role="note"><span>Note:</span> The Fetch specification will hook into this algorithm to upgrade optionally-blockable
+    mixed content to HTTPS.</p>
+     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request">Request</a> <var>request</var>, this algorithm will rewrite
+    its <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url">url</a> if the request is deemed to be optionally-blockable mixed content,
+    via the following algorithm:</p>
+     <ol>
+      <li>
+        If one or more of the following conditions is met, return without modifying <var>request</var>: 
+       <ol>
+        <li> <a href="https://www.w3.org/TR/mixed-content/#categorize-settings-object">Mixed Content §categorize-settings-object</a> returns "<code>Does Not Restrict Mixed Security
+            Contents</code>" when applied to <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client">client</a>. 
+        <li> <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-mode" id="ref-for-concept-request-mode">mode</a> is <code>CORS</code> or <code>CORS-with-forced-preflight</code>. 
+        <li> <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination">destination</a> is not "<code>image</code>",
+            "<code>audio</code>", or "<code>video</code>". 
+        <li> <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination①">destination</a> is "<code>image</code>"
+            and <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-initiator" id="ref-for-concept-request-initiator">initiator</a> is "<code>imageset</code>". 
+        <li> <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url①">url</a> is an <a href="https://www.w3.org/TR/mixed-content/#a-priori-authenticated-url">Mixed Content §a-priori-authenticated-url</a>. 
+       </ol>
+      <li> If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url②">url</a>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme">scheme</a> is <code>http</code>,
+        set <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url③">url</a>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme①">scheme</a> to <code>https</code>, and return. 
+      <li> If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url④">url</a>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-port" id="ref-for-concept-url-port">port</a> is <code>80</code>,
+        set <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url⑤">url</a>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-port" id="ref-for-concept-url-port①">port</a> to <code>443</code>. 
+     </ol>
     </section>
     <section>
      <h3 class="heading settled" data-level="3.2" id="modifications"><span class="secno">3.2. </span><span class="content">Modifications to existing algorithms</span><a class="self-link" href="#modifications"></a></h3>
-     <p>TODO. Modify "Should fetching <var>request</var> be blocked as mixed content?" and "Should <var>response</var> to <var>request</var> be blocked as mixed content?" to ignore the optionally-blockable/blockable distinction. (All content that isn’t autoupgraded should be blocked.)</p>
+     <p class="note" role="note"><span>Note:</span> This section specifies modifications to existing mixed content algorithms to ignore the
+    distinction between optionally-blockable and blockable mixed content, since all
+    optionally-blockable mixed content will now be autoupgraded.</p>
+     <p><a href="https://www.w3.org/TR/mixed-content/#should-block-fetch">Mixed Content §should-block-fetch</a> should be modified to remove Steps 3, 4, and 5, replacing
+    them with a single step "Return <strong>blocked</strong>".</p>
+     <p><a href="https://www.w3.org/TR/mixed-content/#should-block-response">Mixed Content §should-block-response</a> should be modified to remove Steps 2, 3, and 4,
+    replacing them with a single step "Return <strong>blocked</strong>".</p>
     </section>
     <section>
      <h2 class="heading settled" data-level="4" id="integration"><span class="secno">4. </span><span class="content">Integrations</span><a class="self-link" href="#integration"></a></h2>
-     <p>TODO. Call the autoupgrading algorithm from Fetch.</p>
-     <p>TODO. Something about blocking insecure downloads from secure contexts (integrate with HTML).</p>
+     <h3 class="heading settled" data-level="4.1" id="fetch"><span class="secno">4.1. </span><span class="content">Modifications to Fetch</span><a class="self-link" href="#fetch"></a></h3>
+     <p><a href="https://fetch.spec.whatwg.org/#main-fetch">Fetch Standard §4.1 Main fetch</a> should be modified to call <a href="#upgrade-algorithm">§ 3.1 Upgrade request to an a priori
+    authenticated URL as mixed content, if appropriate</a> on <var>request</var> between steps 3 and 4. That is, optionally-blockable mixed content should be autoupgraded to HTTPS
+  before applying mixed content blocking.</p>
     </section>
     <section>
      <h2 class="heading settled" data-level="5" id="obsolescences"><span class="secno">5. </span><span class="content">Obsolescences</span><a class="self-link" href="#obsolescences"></a></h2>
-     <p>TODO. block-all-mixed-content is obsolete. Clarify the value of
-  upgrade-insecure-requests (upgrades blockable content as well as
-  optionally-blockable).</p>
+     <h3 class="heading settled" data-level="5.1" id="block-all-mixed-content"><span class="secno">5.1. </span><span class="content"><code>block-all-mixed-content</code></span><a class="self-link" href="#block-all-mixed-content"></a></h3>
+     <p>This specification renders the <a href="https://www.w3.org/TR/mixed-content/#block-all-mixed-content">Mixed Content §block-all-mixed-content</a> CSP directive obsolete,
+  because all mixed content is now blocked if it can’t be autoupgraded.</p>
+     <p class="note" role="note"><span>Note:</span> The <code>upgrade-insecure-requests</code> (<a data-link-type="biblio" href="#biblio-upgrade-insecure-requests">[upgrade-insecure-requests]</a>) directive is not
+  obsolete because it allows developers to upgrade blockable content. This specification only
+  upgrades optionally-blockable content by default.</p>
     </section>
     <section>
      <h2 class="heading settled" data-level="6" id="security-considerations"><span class="secno">6. </span><span class="content">Security and Privacy Considerations</span><a class="self-link" href="#security-considerations"></a></h2>
@@ -1536,11 +1620,152 @@ pre .property::before, pre .property::after {
     be easy to understand and are not intended to be performant. Implementers
     are encouraged to optimize.</p>
 <script src="https://www.w3.org/scripts/TR/2016/fixup.js"></script>
+  <h2 class="no-num no-ref heading settled" id="index"><span class="content">Index</span><a class="self-link" href="#index"></a></h2>
+  <aside class="dfn-panel" data-for="term-for-concept-request-client">
+   <a href="https://fetch.spec.whatwg.org/#concept-request-client">https://fetch.spec.whatwg.org/#concept-request-client</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-concept-request-client">3.1. Upgrade request to an a priori
+    authenticated URL as mixed content, if appropriate</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-concept-request-destination">
+   <a href="https://fetch.spec.whatwg.org/#concept-request-destination">https://fetch.spec.whatwg.org/#concept-request-destination</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-concept-request-destination">3.1. Upgrade request to an a priori
+    authenticated URL as mixed content, if appropriate</a> <a href="#ref-for-concept-request-destination①">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-concept-request-initiator">
+   <a href="https://fetch.spec.whatwg.org/#concept-request-initiator">https://fetch.spec.whatwg.org/#concept-request-initiator</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-concept-request-initiator">3.1. Upgrade request to an a priori
+    authenticated URL as mixed content, if appropriate</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-concept-request-mode">
+   <a href="https://fetch.spec.whatwg.org/#concept-request-mode">https://fetch.spec.whatwg.org/#concept-request-mode</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-concept-request-mode">3.1. Upgrade request to an a priori
+    authenticated URL as mixed content, if appropriate</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-concept-request">
+   <a href="https://fetch.spec.whatwg.org/#concept-request">https://fetch.spec.whatwg.org/#concept-request</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-concept-request">3.1. Upgrade request to an a priori
+    authenticated URL as mixed content, if appropriate</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-concept-request-url">
+   <a href="https://fetch.spec.whatwg.org/#concept-request-url">https://fetch.spec.whatwg.org/#concept-request-url</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-concept-request-url">3.1. Upgrade request to an a priori
+    authenticated URL as mixed content, if appropriate</a> <a href="#ref-for-concept-request-url①">(2)</a> <a href="#ref-for-concept-request-url②">(3)</a> <a href="#ref-for-concept-request-url③">(4)</a> <a href="#ref-for-concept-request-url④">(5)</a> <a href="#ref-for-concept-request-url⑤">(6)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-concept-url-port">
+   <a href="https://url.spec.whatwg.org/#concept-url-port">https://url.spec.whatwg.org/#concept-url-port</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-concept-url-port">3.1. Upgrade request to an a priori
+    authenticated URL as mixed content, if appropriate</a> <a href="#ref-for-concept-url-port①">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-concept-url-scheme">
+   <a href="https://url.spec.whatwg.org/#concept-url-scheme">https://url.spec.whatwg.org/#concept-url-scheme</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-concept-url-scheme">3.1. Upgrade request to an a priori
+    authenticated URL as mixed content, if appropriate</a> <a href="#ref-for-concept-url-scheme①">(2)</a>
+   </ul>
+  </aside>
+  <h3 class="no-num no-ref heading settled" id="index-defined-elsewhere"><span class="content">Terms defined by reference</span><a class="self-link" href="#index-defined-elsewhere"></a></h3>
+  <ul class="index">
+   <li>
+    <a data-link-type="biblio">[FETCH]</a> defines the following terms:
+    <ul>
+     <li><span class="dfn-paneled" id="term-for-concept-request-client" style="color:initial">client</span>
+     <li><span class="dfn-paneled" id="term-for-concept-request-destination" style="color:initial">destination</span>
+     <li><span class="dfn-paneled" id="term-for-concept-request-initiator" style="color:initial">initiator</span>
+     <li><span class="dfn-paneled" id="term-for-concept-request-mode" style="color:initial">mode</span>
+     <li><span class="dfn-paneled" id="term-for-concept-request" style="color:initial">request</span>
+     <li><span class="dfn-paneled" id="term-for-concept-request-url" style="color:initial">url</span>
+    </ul>
+   <li>
+    <a data-link-type="biblio">[URL]</a> defines the following terms:
+    <ul>
+     <li><span class="dfn-paneled" id="term-for-concept-url-port" style="color:initial">port</span>
+     <li><span class="dfn-paneled" id="term-for-concept-url-scheme" style="color:initial">scheme</span>
+    </ul>
+  </ul>
   <h2 class="no-num no-ref heading settled" id="references"><span class="content">References</span><a class="self-link" href="#references"></a></h2>
   <h3 class="no-num no-ref heading settled" id="normative"><span class="content">Normative References</span><a class="self-link" href="#normative"></a></h3>
   <dl>
+   <dt id="biblio-fetch">[FETCH]
+   <dd>Anne van Kesteren. <a href="https://fetch.spec.whatwg.org/">Fetch Standard</a>. Living Standard. URL: <a href="https://fetch.spec.whatwg.org/">https://fetch.spec.whatwg.org/</a>
    <dt id="biblio-mixed-content">[MIXED-CONTENT]
    <dd>Mike West. <a href="https://www.w3.org/TR/mixed-content/">Mixed Content</a>. 2 August 2016. CR. URL: <a href="https://www.w3.org/TR/mixed-content/">https://www.w3.org/TR/mixed-content/</a>
    <dt id="biblio-rfc2119">[RFC2119]
    <dd>S. Bradner. <a href="https://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>. March 1997. Best Current Practice. URL: <a href="https://tools.ietf.org/html/rfc2119">https://tools.ietf.org/html/rfc2119</a>
+   <dt id="biblio-url">[URL]
+   <dd>Anne van Kesteren. <a href="https://url.spec.whatwg.org/">URL Standard</a>. Living Standard. URL: <a href="https://url.spec.whatwg.org/">https://url.spec.whatwg.org/</a>
   </dl>
+  <h3 class="no-num no-ref heading settled" id="informative"><span class="content">Informative References</span><a class="self-link" href="#informative"></a></h3>
+  <dl>
+   <dt id="biblio-upgrade-insecure-requests">[UPGRADE-INSECURE-REQUESTS]
+   <dd>Mike West. <a href="https://www.w3.org/TR/upgrade-insecure-requests/">Upgrade Insecure Requests</a>. 8 October 2015. CR. URL: <a href="https://www.w3.org/TR/upgrade-insecure-requests/">https://www.w3.org/TR/upgrade-insecure-requests/</a>
+  </dl>
+<script>/* script-dfn-panel */
+
+document.body.addEventListener("click", function(e) {
+    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
+    // Find the dfn element or panel, if any, that was clicked on.
+    var el = e.target;
+    var target;
+    var hitALink = false;
+    while(el.parentElement) {
+        if(el.tagName == "A") {
+            // Clicking on a link in a <dfn> shouldn't summon the panel
+            hitALink = true;
+        }
+        if(el.classList.contains("dfn-paneled")) {
+            target = "dfn";
+            break;
+        }
+        if(el.classList.contains("dfn-panel")) {
+            target = "dfn-panel";
+            break;
+        }
+        el = el.parentElement;
+    }
+    if(target != "dfn-panel") {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
+            el.classList.remove("on");
+            el.classList.remove("activated");
+        });
+    }
+    if(target == "dfn" && !hitALink) {
+        // open the panel
+        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
+        if(dfnPanel) {
+            dfnPanel.classList.add("on");
+            var rect = el.getBoundingClientRect();
+            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
+            dfnPanel.style.top = window.scrollY + rect.top + "px";
+            var panelRect = dfnPanel.getBoundingClientRect();
+            var panelWidth = panelRect.right - panelRect.left;
+            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
+                // Reposition, because the panel is overflowing
+                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
+            }
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
+        }
+    } else if(target == "dfn-panel") {
+        // Switch it to "activated" state, which pins it.
+        el.classList.add("activated");
+        el.style.left = null;
+        el.style.top = null;
+    }
+
+});
+</script>

--- a/level2.html
+++ b/level2.html
@@ -1214,7 +1214,7 @@ Possible extra rowspan handling
 </style>
   <meta content="Bikeshed version a3b64e58e069c2e8a9ffcadffb76601231663a47" name="generator">
   <link href="https://w3c.github.io/webappsec-mixed-content/level2.html" rel="canonical">
-  <meta content="ba231f96df766bbb28908883799e400081e2578f" name="document-revision">
+  <meta content="4df6353a078559c9ec3360176053fe7ed13eb5a1" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -1403,7 +1403,7 @@ pre .property::before, pre .property::after {
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1>Mixed Content Level 2</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2019-08-20">20 August 2019</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2019-08-22">22 August 2019</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1538,19 +1538,17 @@ pre .property::before, pre .property::after {
       <li>
         If one or more of the following conditions is met, return without modifying <var>request</var>: 
        <ol>
+        <li> <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url①">url</a> is an <a href="https://www.w3.org/TR/mixed-content/#a-priori-authenticated-url">Mixed Content §a-priori-authenticated-url</a>. 
         <li> <a href="https://www.w3.org/TR/mixed-content/#categorize-settings-object">Mixed Content §categorize-settings-object</a> returns "<code>Does Not Restrict Mixed Security
             Contents</code>" when applied to <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client">client</a>. 
-        <li> <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-mode" id="ref-for-concept-request-mode">mode</a> is <code>CORS</code> or <code>CORS-with-forced-preflight</code>. 
+        <li> <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-mode" id="ref-for-concept-request-mode">mode</a> is <code>CORS</code>. 
         <li> <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination">destination</a> is not "<code>image</code>",
             "<code>audio</code>", or "<code>video</code>". 
         <li> <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination①">destination</a> is "<code>image</code>"
             and <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-initiator" id="ref-for-concept-request-initiator">initiator</a> is "<code>imageset</code>". 
-        <li> <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url①">url</a> is an <a href="https://www.w3.org/TR/mixed-content/#a-priori-authenticated-url">Mixed Content §a-priori-authenticated-url</a>. 
        </ol>
       <li> If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url②">url</a>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme">scheme</a> is <code>http</code>,
         set <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url③">url</a>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme①">scheme</a> to <code>https</code>, and return. 
-      <li> If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url④">url</a>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-port" id="ref-for-concept-url-port">port</a> is <code>80</code>,
-        set <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url⑤">url</a>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-port" id="ref-for-concept-url-port①">port</a> to <code>443</code>. 
      </ol>
     </section>
     <section>
@@ -1660,14 +1658,7 @@ pre .property::before, pre .property::after {
    <a href="https://fetch.spec.whatwg.org/#concept-request-url">https://fetch.spec.whatwg.org/#concept-request-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-url">3.1. Upgrade request to an a priori
-    authenticated URL as mixed content, if appropriate</a> <a href="#ref-for-concept-request-url①">(2)</a> <a href="#ref-for-concept-request-url②">(3)</a> <a href="#ref-for-concept-request-url③">(4)</a> <a href="#ref-for-concept-request-url④">(5)</a> <a href="#ref-for-concept-request-url⑤">(6)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-port">
-   <a href="https://url.spec.whatwg.org/#concept-url-port">https://url.spec.whatwg.org/#concept-url-port</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-concept-url-port">3.1. Upgrade request to an a priori
-    authenticated URL as mixed content, if appropriate</a> <a href="#ref-for-concept-url-port①">(2)</a>
+    authenticated URL as mixed content, if appropriate</a> <a href="#ref-for-concept-request-url①">(2)</a> <a href="#ref-for-concept-request-url②">(3)</a> <a href="#ref-for-concept-request-url③">(4)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-url-scheme">
@@ -1692,7 +1683,6 @@ pre .property::before, pre .property::after {
    <li>
     <a data-link-type="biblio">[URL]</a> defines the following terms:
     <ul>
-     <li><span class="dfn-paneled" id="term-for-concept-url-port" style="color:initial">port</span>
      <li><span class="dfn-paneled" id="term-for-concept-url-scheme" style="color:initial">scheme</span>
     </ul>
   </ul>

--- a/level2.src.html
+++ b/level2.src.html
@@ -84,29 +84,90 @@ type: attribute
     <h3 id="upgrade-algorithm">Upgrade |request| to an <i lang="la">a priori</i>
     authenticated URL as mixed content, if appropriate</h3>
 
-    TODO. This algorithm is called from Fetch before blocking requests as mixed content. It checks if the request is optionally-blockable mixed content, and if so rewrites the scheme to HTTPS.
+    Note: The Fetch specification will hook into this algorithm to upgrade optionally-blockable
+    mixed content to HTTPS.
+
+    Given a <a>Request</a> <var>request</var>, this algorithm will rewrite
+    its <a for="request">url</a> if the request is deemed to be optionally-blockable mixed content,
+    via the following algorithm:
+
+    <ol>
+      <li>
+        If one or more of the following conditions is met, return without modifying <var>request</var>:
+        <ol>
+          <li>
+            [[mixed-content#categorize-settings-object]] returns "<code>Does Not Restrict Mixed Security
+            Contents</code>" when applied to <var>request</var>'s <a for="request">client</a>.
+          </li>
+          <li>
+            <var>request</var>'s <a for="request">mode</a> is <code>CORS</code>
+            or <code>CORS-with-forced-preflight</code>.
+          </li>
+          <li>
+            <var>request</var>'s <a for="request">destination</a> is not "<code>image</code>",
+            "<code>audio</code>", or "<code>video</code>".
+          </li>
+          <li>
+            <var>request</var>'s <a for="request">destination</a> is "<code>image</code>"
+            and <var>request</var>'s <a for="request">initiator</a> is "<code>imageset</code>".
+          </li>
+          <li>
+            <var>request</var>'s <a for="request">url</a> is an
+            [[mixed-content#a-priori-authenticated-url]].
+          </li>
+        </ol>
+      </li>
+      <li>
+        If <var>request</var>'s <a for="request">url</a>'s <a for="url">scheme</a>
+        is <code>http</code>,
+        set <var>request</var>'s <a for="request">url</a>'s <a for="url">scheme</a>
+        to <code>https</code>, and return.        
+      </li>
+      <li>
+        If <var>request</var>'s <a for="request">url</a>'s <a for="url">port</a> is <code>80</code>,
+        set <var>request</var>'s <a for="request">url</a>'s <a for="url">port</a>
+        to <code>443</code>.
+      </li>
+    </ol>  
+
   </section>
 
   <section>
     <h3 id="modifications">Modifications to existing algorithms</h3>
 
-    TODO. Modify "Should fetching |request| be blocked as mixed content?" and "Should |response| to |request| be blocked as mixed content?" to ignore the optionally-blockable/blockable distinction. (All content that isn't autoupgraded should be blocked.)
+    Note: This section specifies modifications to existing mixed content algorithms to ignore the
+    distinction between optionally-blockable and blockable mixed content, since all
+    optionally-blockable mixed content will now be autoupgraded.
+
+    [[mixed-content#should-block-fetch]] should be modified to remove Steps 3, 4, and 5, replacing
+    them with a single step "Return <strong>blocked</strong>".
+
+    [[mixed-content#should-block-response]] should be modified to remove Steps 2, 3, and 4,
+    replacing them with a single step "Return <strong>blocked</strong>".
 </section>
 
 <section>
   <h2 id="integration">Integrations</h2>
 
-  TODO. Call the autoupgrading algorithm from Fetch.
+  <h3 id="fetch">Modifications to Fetch</h3>
 
-  TODO. Something about blocking insecure downloads from secure contexts (integrate with HTML).
+  [[fetch#main-fetch]] should be modified to call [[#upgrade-algorithm]] on <var>request</var>
+  between steps 3 and 4. That is, optionally-blockable mixed content should be autoupgraded to HTTPS
+  before applying mixed content blocking.
+
 </section>
 
 <section>
   <h2 id="obsolescences">Obsolescences</h2>
 
-  TODO. block-all-mixed-content is obsolete. Clarify the value of
-  upgrade-insecure-requests (upgrades blockable content as well as
-  optionally-blockable).
+  <h3 id="block-all-mixed-content"><code>block-all-mixed-content</code></h3>
+
+  This specification renders the [[mixed-content#block-all-mixed-content]] CSP directive obsolete,
+  because all mixed content is now blocked if it can't be autoupgraded.
+
+  Note: The <code>upgrade-insecure-requests</code> ([[upgrade-insecure-requests]]) directive is not
+  obsolete because it allows developers to upgrade blockable content. This specification only
+  upgrades optionally-blockable content by default.
 </section>
 
 <section>

--- a/level2.src.html
+++ b/level2.src.html
@@ -120,9 +120,13 @@ type: attribute
         If <var>request</var>'s <a for="request">url</a>'s <a for="url">scheme</a>
         is <code>http</code>,
         set <var>request</var>'s <a for="request">url</a>'s <a for="url">scheme</a>
-        to <code>https</code>, and return.        
+        to <code>https</code>, and return.
+
+        Note: Per [[url]], we do not modify the port because it will be set to null when the scheme
+        is <code>http</code>, and interpreted as 443 once the scheme is changed
+        to <code>https</code>
       </li>
-    </ol>  
+    </ol>
 
   </section>
 

--- a/level2.src.html
+++ b/level2.src.html
@@ -96,12 +96,15 @@ type: attribute
         If one or more of the following conditions is met, return without modifying <var>request</var>:
         <ol>
           <li>
+            <var>request</var>'s <a for="request">url</a> is an
+            [[mixed-content#a-priori-authenticated-url]].
+          </li>
+          <li>
             [[mixed-content#categorize-settings-object]] returns "<code>Does Not Restrict Mixed Security
             Contents</code>" when applied to <var>request</var>'s <a for="request">client</a>.
           </li>
           <li>
-            <var>request</var>'s <a for="request">mode</a> is <code>CORS</code>
-            or <code>CORS-with-forced-preflight</code>.
+            <var>request</var>'s <a for="request">mode</a> is <code>CORS</code>.
           </li>
           <li>
             <var>request</var>'s <a for="request">destination</a> is not "<code>image</code>",
@@ -111,10 +114,6 @@ type: attribute
             <var>request</var>'s <a for="request">destination</a> is "<code>image</code>"
             and <var>request</var>'s <a for="request">initiator</a> is "<code>imageset</code>".
           </li>
-          <li>
-            <var>request</var>'s <a for="request">url</a> is an
-            [[mixed-content#a-priori-authenticated-url]].
-          </li>
         </ol>
       </li>
       <li>
@@ -122,11 +121,6 @@ type: attribute
         is <code>http</code>,
         set <var>request</var>'s <a for="request">url</a>'s <a for="url">scheme</a>
         to <code>https</code>, and return.        
-      </li>
-      <li>
-        If <var>request</var>'s <a for="request">url</a>'s <a for="url">port</a> is <code>80</code>,
-        set <var>request</var>'s <a for="request">url</a>'s <a for="url">port</a>
-        to <code>443</code>.
       </li>
     </ol>  
 


### PR DESCRIPTION
This adds an algorithm to autoupgrade optionally-blockable content to
HTTPS, and makes modifications to existing mixed content algorithms to
block optionally-blockable content that can't be autoupgraded.