### PR TITLE
Include concepts from MIX in MIX2

### DIFF
--- a/level2.fpwd.html
+++ b/level2.fpwd.html
@@ -7,7 +7,7 @@
   <link href="https://www.w3.org/StyleSheets/TR/2016/W3C-WD" rel="stylesheet" type="text/css">
   <meta content="Bikeshed version e1a165f1c2fb1cc2aceb87e110984a42830c36fa" name="generator">
   <link href="https://www.w3.org/TR/mixed-content-2/" rel="canonical">
-  <meta content="e85f5805718759b48d2e9603124c1a8ffa44e390" name="document-revision">
+  <meta content="70f2ee524feedbfaa07d52894e3f6cdd0ec6dcb6" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -196,11 +196,11 @@ pre .property::before, pre .property::after {
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1>Mixed Content Level 2</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">W3C First Public Working Draft, <time class="dt-updated" datetime="2019-12-03">3 December 2019</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">W3C First Public Working Draft, <time class="dt-updated" datetime="2020-03-20">20 March 2020</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
-     <dd><a class="u-url" href="https://www.w3.org/TR/2019/WD-mixed-content-2-2-20191203/">https://www.w3.org/TR/2019/WD-mixed-content-2-2-20191203/</a>
+     <dd><a class="u-url" href="https://www.w3.org/TR/2020/WD-mixed-content-2-2-20200320/">https://www.w3.org/TR/2020/WD-mixed-content-2-2-20200320/</a>
      <dt>Latest published version:
      <dd><a href="https://www.w3.org/TR/mixed-content-2/">https://www.w3.org/TR/mixed-content-2/</a>
      <dt>Editor's Draft:
@@ -219,7 +219,7 @@ pre .property::before, pre .property::after {
     </dl>
    </div>
    <div data-fill-with="warning"></div>
-   <p class="copyright" data-fill-with="copyright"><a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2019 <a href="https://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup> (<a href="https://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>, <a href="https://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>, <a href="https://www.keio.ac.jp/">Keio</a>, <a href="https://ev.buaa.edu.cn/">Beihang</a>). W3C <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="https://www.w3.org/Consortium/Legal/copyright-documents">document use</a> rules apply. </p>
+   <p class="copyright" data-fill-with="copyright"><a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2020 <a href="https://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup> (<a href="https://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>, <a href="https://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>, <a href="https://www.keio.ac.jp/">Keio</a>, <a href="https://ev.buaa.edu.cn/">Beihang</a>). W3C <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="https://www.w3.org/Consortium/Legal/copyright-documents">document use</a> rules apply. </p>
    <hr title="Separator for header">
   </div>
   <div class="p-summary" data-fill-with="abstract">
@@ -264,23 +264,41 @@ pre .property::before, pre .property::after {
     <li><a href="#intro"><span class="secno">1</span> <span class="content">Introduction</span></a>
     <li><a href="#terms"><span class="secno">2</span> <span class="content">Key Concepts and Terminology</span></a>
     <li>
-     <a href="#algorithms"><span class="secno">3</span> <span class="content">Algorithms</span></a>
+     <a href="#categories"><span class="secno">3</span> <span class="content">Content Categories</span></a>
      <ol class="toc">
-      <li><a href="#upgrade-algorithm"><span class="secno">3.1</span> <span class="content">Upgrade <var>request</var> to an <i lang="la">a priori</i> authenticated URL as mixed content, if appropriate</span></a>
-      <li><a href="#modifications"><span class="secno">3.2</span> <span class="content">Modifications to existing algorithms</span></a>
+      <li><a href="#category-optionally-blockable"><span class="secno">3.1</span> <span class="content">Optionally-blockable Content</span></a>
+      <li><a href="#category-blockable"><span class="secno">3.2</span> <span class="content">Blockable Content</span></a>
      </ol>
     <li>
-     <a href="#integration"><span class="secno">4</span> <span class="content">Integrations</span></a>
+     <a href="#algorithms"><span class="secno">4</span> <span class="content">Algorithms</span></a>
      <ol class="toc">
-      <li><a href="#fetch"><span class="secno">4.1</span> <span class="content">Modifications to Fetch</span></a>
+      <li><a href="#upgrade-algorithm"><span class="secno">4.1</span> <span class="content">Upgrade <var>request</var> to an <i lang="la">a priori</i> authenticated URL as mixed content, if appropriate</span></a>
+      <li><a href="#existing-mix-algorithms"><span class="secno">4.2</span> <span class="content">Existing Mixed Content Algorithms and Modifications</span></a>
+      <li><a href="#categorize-settings-object"><span class="secno">4.3</span> <span class="content"> Does <var>settings</var> prohibit mixed security contexts? </span></a>
+      <li><a href="#should-block-fetch"><span class="secno">4.4</span> <span class="content"> Should fetching <var>request</var> be blocked as mixed content? </span></a>
+      <li><a href="#should-block-response"><span class="secno">4.5</span> <span class="content"> Should <var>response</var> to <var>request</var> be blocked as mixed
+      content? </span></a>
      </ol>
     <li>
-     <a href="#obsolescences"><span class="secno">5</span> <span class="content">Obsolescences</span></a>
+     <a href="#integration"><span class="secno">5</span> <span class="content">Integrations</span></a>
      <ol class="toc">
-      <li><a href="#block-all-mixed-content"><span class="secno">5.1</span> <span class="content"><code>block-all-mixed-content</code></span></a>
+      <li><a href="#fetch"><span class="secno">5.1</span> <span class="content">Modifications to Fetch</span></a>
+      <li><a href="#html"><span class="secno">5.2</span> <span class="content">Modifications to HTML</span></a>
      </ol>
-    <li><a href="#security-considerations"><span class="secno">6</span> <span class="content">Security and Privacy Considerations</span></a>
-    <li><a href="#acknowledgements"><span class="secno">7</span> <span class="content">Acknowledgements</span></a>
+    <li>
+     <a href="#obsolescences"><span class="secno">6</span> <span class="content">Obsolescences</span></a>
+     <ol class="toc">
+      <li><a href="#block-all-mixed-content"><span class="secno">6.1</span> <span class="content"><code>block-all-mixed-content</code></span></a>
+      <li><a href="#mixed-content-1"><span class="secno">6.2</span> <span class="content"><code>Mixed Content</code></span></a>
+     </ol>
+    <li><a href="#websockets-integration"><span class="secno">7</span> <span class="content">Modifications to WebSockets</span></a>
+    <li>
+     <a href="#security-considerations"><span class="secno">8</span> <span class="content">Security and Privacy Considerations</span></a>
+     <ol class="toc">
+      <li><a href="#requirements-forms"><span class="secno">8.1</span> <span class="content">Form Submission</span></a>
+      <li><a href="#requirements-user-controls"><span class="secno">8.2</span> <span class="content">User Controls</span></a>
+     </ol>
+    <li><a href="#acknowledgements"><span class="secno">9</span> <span class="content">Acknowledgements</span></a>
     <li>
      <a href="#conformance"><span class="secno"></span> <span class="content">Conformance</span></a>
      <ol class="toc">
@@ -290,6 +308,7 @@ pre .property::before, pre .property::after {
     <li>
      <a href="#index"><span class="secno"></span> <span class="content">Index</span></a>
      <ol class="toc">
+      <li><a href="#index-defined-here"><span class="secno"></span> <span class="content">Terms defined by this specification</span></a>
       <li><a href="#index-defined-elsewhere"><span class="secno"></span> <span class="content">Terms defined by reference</span></a>
      </ol>
     <li>
@@ -315,12 +334,13 @@ pre .property::before, pre .property::after {
   (e.g., a fabricated stock chart), mutate client-side state (e.g., set a
   cookie), or induce the user to take an unintended action (e.g., changing the
   label on a button). These requests are known as mixed content.</p>
-    <p><a data-link-type="biblio" href="#biblio-mixed-content">[MIXED-CONTENT]</a> details how a user agent can mitigate these risks by
+    <p><a data-link-type="biblio" href="#biblio-mixed-content">[mixed-content]</a> details how a user agent can mitigate these risks by
   blocking certain types of mixed content, and behaving more strictly in some
   contexts.</p>
-    <p>However, as implemented in today’s web browsers, <a data-link-type="biblio" href="#biblio-mixed-content">[MIXED-CONTENT]</a> does not fully protect the
+    <p>However, as implemented in today’s web browsers, <a data-link-type="biblio" href="#biblio-mixed-content">[mixed-content]</a> does not fully protect the
   confidentiality and integrity of users' data. Insecure content such as images, audio, and video
-  can currently be loaded by default in secure contexts.</p>
+  can currently be loaded by default in secure contexts. Secure pages can even initiate insecure
+  downloads which escape the user agent’s sandbox entirely.</p>
     <p>Moreover, users do not have a clear security indicator when mixed content is loaded. When a
   webpage loads mixed content, browsers display an "in-between" security indicator (such as removing
   the padlock icon), which does not give users a clear indication of whether they should trust the
@@ -329,83 +349,363 @@ pre .property::before, pre .property::after {
   provide the user with a simpler mental model -- the webpage is either loaded over a secure
   transport or it isn’t -- and encourage developers to securely load any mixed content that is
   necessary for their webpage to function properly.</p>
-    <p>Mixed Content Level 2 therefore updates and extends <a data-link-type="biblio" href="#biblio-mixed-content">[MIXED-CONTENT]</a> to provide users with
+    <p>Mixed Content Level 2 therefore updates and extends <a data-link-type="biblio" href="#biblio-mixed-content">[mixed-content]</a> to provide users with
   better security and privacy guarantees and a better security UX, while minimizing
   breakage. Instead of advising browsers to simply strictly block all mixed content, the core idea
   of Level 2 is <i>mixed content autoupgrading</i>. That is, mixed content that user agents are not
   already blocking should be autoupgraded to a secure transport. If the request cannot be
   autoupgraded, it will be blocked. Autoupgrading avoids loading insecure resources on secure
   webpages, while minimizing the amount of developer effort needed to avoid breakage.</p>
-    <p>This specification (Level 2) only recommends autoupgrading types of mixed content that are not
-  currently blocked by default, and does not recommend autougprading types of content that are
-  already blocked. This is to minimize the amount of web-visible change; we only want to autoupgrade
-  content if it advances us towards the goal of blocking all mixed content by default.</p>
+    <p>This specification (Level 2) only recommends autoupgrading types of mixed content subresources
+  that are not currently blocked by default, and does not recommend autougprading types of content
+  that are already blocked. This is to minimize the amount of web-visible change; we only want to
+  autoupgrade content if it advances us towards the goal of blocking all mixed content by default.</p>
+    <p>This specification also explicitly introduces the concept of <i>mixed downloads</i>. A mixed
+  download is a resource that a user agent handles as a download, which was initiated by a secure
+  context but is downloaded over an insecure connection. User agents should block mixed downloads
+  because they can escape the user agent’s sandbox (in the case of an executable) or contain
+  sensitive information (e.g., a downloaded bank statement). This is especially misleading because
+  user agents typically indicates to the user that they are on a secure page while initiating and
+  completing a mixed download.</p>
    </section>
    <section>
     <h2 class="heading settled" data-level="2" id="terms"><span class="secno">2. </span><span class="content">Key Concepts and Terminology</span><a class="self-link" href="#terms"></a></h2>
-    <p>TODO</p>
+    <dl>
+     <dt> <dfn class="dfn-paneled" data-dfn-type="dfn" data-export data-local-lt="mixed" id="mixed-content">mixed content</dfn> 
+     <dd>
+       A <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request">request</a> is <strong>mixed content</strong> if its <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url">url</a> is not <a data-link-type="dfn" href="#a-priori-authenticated-url" id="ref-for-a-priori-authenticated-url"><i lang="la">a priori</i> authenticated</a>, <strong>and</strong> the context responsible for
+      loading it requires prohibits mixed security contexts (see <a href="#categorize-settings-object">§ 4.3 Does settings prohibit mixed security contexts?</a> for a normative definition of the latter). 
+      <p>A <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response">response</a> is <strong>mixed content</strong> if it is an <a data-link-type="dfn" href="#unauthenticated-response" id="ref-for-unauthenticated-response">unauthenticated response</a>, <strong>and</strong> the context
+      responsible for loading it requires prohibits mixed security contexts.</p>
+      <div class="example" id="example-13a780ee">
+       <a class="self-link" href="#example-13a780ee"></a> Inside a context that restricts mixed content
+        (<code>https://secure.example.com/</code>, for example): 
+       <ol>
+        <li data-md>
+         <p>A request for the script <code>http://example.com/script.js</code> is <strong>mixed content</strong>. As script <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request①">requests</a> are <a data-link-type="dfn" href="#blockable-mixed-content" id="ref-for-blockable-mixed-content">blockable</a>, the user agent will return a network error rather
+  than loading the resource.</p>
+        <li data-md>
+         <p>A request for the image <code>http://example.com/image.png</code> is <strong>mixed content</strong>. As image <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②">requests</a> are <a data-link-type="dfn" href="#optionally-blockable-mixed-content" id="ref-for-optionally-blockable-mixed-content">optionally-blockable</a>, the user agent might load the image, in
+  which case the image resource itself would be <strong>mixed
+  content</strong>.</p>
+       </ol>
+      </div>
+      <p>If mixed content is loaded into a context that restricts mixed content
+      (as in #2 above), that context is considered a <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6797#section-12.4" id="ref-for-section-12.4">mixed security
+      context</a> (as defined in <a data-link-type="biblio" href="#biblio-rfc6797">[RFC6797]</a>).</p>
+      <p class="note" role="note"><span>Note:</span> "Mixed content" was originally defined in <a href="https://www.w3.org/TR/wsc-ui/#securepage">section 5.3</a> of <a data-link-type="biblio" href="#biblio-wsc-ui">[WSC-UI]</a>. This document updates that initial definition.</p>
+      <p class="note" role="note"><span>Note:</span> <a data-link-type="biblio" href="#biblio-xml">[XML]</a> also defines an unrelated <a href="https://www.w3.org/TR/2008/REC-xml-20081126/#sec-mixed-content">"mixed content"</a>.
+      concept. This is potentially confusing, but given the term’s near
+      ubiquitious usage in a security context across user agents for more than
+      a decade, the practical risk of confusion seems low.</p>
+     <dt> <dfn class="dfn-paneled" data-dfn-type="dfn" data-export data-local-lt="a priori authenticated" data-lt="a priori authenticated URL" id="a-priori-authenticated-url"> <i lang="la">a priori</i> authenticated URL <span id="a-priori-insecure-url a-priori-insecure-origin"></span></dfn> 
+     <dd>
+       We know <i lang="la">a priori</i> that a request to a particular URL
+      (<var>url</var>) will be delivered in a way that mitigates the risks of
+      interception and modifications if either of the following statements is
+      true: 
+      <ol>
+       <li data-md>
+        <p><var>url</var> is a <a data-link-type="dfn" href="https://w3c.github.io/webappsec-secure-contexts/#potentially-trustworthy-url" id="ref-for-potentially-trustworthy-url">potentially trustworthy URL</a> <a data-link-type="biblio" href="#biblio-secure-contexts">[SECURE-CONTEXTS]</a>.</p>
+       <li data-md>
+        <p><var>url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme">scheme</a> is "<code>data</code>".</p>
+        <p class="note" role="note"><span>Note:</span> We special case <code>data</code> URLs here, as we don’t consider them
+  particularly trustworthy, but we also don’t wish to block them as
+  mixed content, as they never hit the network.</p>
+      </ol>
+     <dt> <dfn class="dfn-paneled" data-dfn-type="dfn" data-export data-local-lt="unauthenticated" data-lt="unauthenticated response" id="unauthenticated-response"> unauthenticated response <span id="insecure-origin insecure-url"></span></dfn> 
+     <dd>
+       We know <i lang="la">a posteriori</i> that a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response①">response</a> (<var>response</var>) is unauthenticated if either of the following statements
+      is false: 
+      <ol>
+       <li data-md>
+        <p><var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-url" id="ref-for-concept-response-url">url</a> is <a data-link-type="dfn" href="#a-priori-authenticated-url" id="ref-for-a-priori-authenticated-url①"><i lang="la">a
+  priori</i> authenticated</a>.</p>
+       <li data-md>
+        <p>If <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-url" id="ref-for-concept-response-url①">url</a>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme①">scheme</a> is "<code>https</code>" or "<code>wss</code>", <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-https-state" id="ref-for-concept-response-https-state">HTTPS
+  state</a> is "<code>modern</code>".</p>
+      </ol>
+     <dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="embedding-document">embedding document</dfn>
+     <dd> Given a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document">Document</a></code> <var>A</var>, the <strong>embedding
+      document</strong> of <var>A</var> is <var>A</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context">browsing context</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#bc-container-document" id="ref-for-bc-container-document">container document</a> <a data-link-type="biblio" href="#biblio-html">[HTML]</a>. 
+     <dt><dfn data-dfn-type="dfn" data-export id="mixed-download">mixed download<a class="self-link" href="#mixed-download"></a></dfn>
+     <dd> A mixed download is a resource that a user agent handles as a download,
+      which was initiated by a secure context but is downloaded over an
+      insecure connection. 
+    </dl>
    </section>
    <section>
-    <h2 class="heading settled" data-level="3" id="algorithms"><span class="secno">3. </span><span class="content">Algorithms</span><a class="self-link" href="#algorithms"></a></h2>
+    <h2 class="heading settled" data-level="3" id="categories"><span class="secno">3. </span><span class="content">Content Categories</span><a class="self-link" href="#categories"></a></h2>
+    <p>In a perfect world, each user agent would be required to block all <a data-link-type="dfn" href="#mixed-content" id="ref-for-mixed-content">mixed
+  content</a> without exception. Unfortunately, that is impractical on today’s
+  Internet; a user agent needs to be more nuanced in its restrictions to avoid
+  degrading the experience on a substantial number of websites.</p>
+    <p>With that in mind, we here split mixed content into two categories: <a href="#category-optionally-blockable">§ 3.1 Optionally-blockable Content</a> and <a href="#category-blockable">§ 3.2 Blockable Content</a>.</p>
+    <p class="note" role="note"><span>Note:</span> Future versions of this specification will update this categorization
+  with the intent of moving towards a world where all <a data-link-type="dfn" href="#mixed-content" id="ref-for-mixed-content①">mixed</a> content is
+  blocked; that is the end goal, but this is the best we can do for now.</p>
     <section>
-     <h3 class="heading settled" data-level="3.1" id="upgrade-algorithm"><span class="secno">3.1. </span><span class="content">Upgrade <var>request</var> to an <i lang="la">a priori</i> authenticated URL as mixed content, if appropriate</span><a class="self-link" href="#upgrade-algorithm"></a></h3>
+     <h3 class="heading settled" data-level="3.1" id="category-optionally-blockable"><span class="secno">3.1. </span><span class="content">Optionally-blockable Content</span><a class="self-link" href="#category-optionally-blockable"></a></h3>
+     <p>Mixed content is <dfn class="dfn-paneled" data-dfn-type="dfn" data-export data-local-lt="optionally-blockable" data-lt="optionally-blockable mixed content" id="optionally-blockable-mixed-content">optionally-blockable</dfn> when the risk of allowing its usage as <a data-link-type="dfn" href="#mixed-content" id="ref-for-mixed-content②">mixed content</a> is outweighed by the risk of
+    breaking significant portions of the web. This could be because mixed usage of the resource type
+    is sufficiently high, and because the resource is low-risk in and of itself. The fact that these
+    resource types are optionally-blockable does not mean that they are <em>safe</em>, simply that
+    they’re less catastrophically dangerous than other resource types. For example, images and icons
+    are often the central UI elements in an application’s interface. If an attacker reversed the
+    "Delete email" and "Reply" icons, there would be real impact to users.</p>
+     <p>This category includes:</p>
+     <ul>
+      <li data-md>
+       <p>Requests whose <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-initiator" id="ref-for-concept-request-initiator">initiator</a> is the empty string, and whose <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination">destination</a> is "<code>image</code>".</p>
+       <p class="note" role="note"><span>Note:</span> This corresponds to most images loaded via <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element" id="ref-for-the-img-element">img</a></code> (including SVG documents loaded as
+  images, as those are blocked from executing script or fetching subresources) and CSS
+  (<a class="property" data-link-type="propdesc" href="https://www.w3.org/TR/css3-background/#propdef-background-image" id="ref-for-propdef-background-image">background-image</a>, <a class="property" data-link-type="propdesc" href="https://www.w3.org/TR/css3-background/#propdef-border-image" id="ref-for-propdef-border-image">border-image</a>, etc). It does not include <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element" id="ref-for-the-img-element①">img</a></code> elements that <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/images.html#use-srcset-or-picture" id="ref-for-use-srcset-or-picture">use
+  srcset or picture</a>.</p>
+      <li data-md>
+       <p>Requests whose <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination①">destination</a> is "<code>video</code>".</p>
+       <p class="note" role="note"><span>Note:</span> This corresponds to video loaded via <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/media.html#video" id="ref-for-video">video</a></code> and <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-source-element" id="ref-for-the-source-element">source</a></code>.</p>
+      <li data-md>
+       <p>Requests whose <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination②">destination</a> is "<code>audio</code>".</p>
+       <p class="note" role="note"><span>Note:</span> This corresponds to audio loaded via <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/media.html#audio" id="ref-for-audio">audio</a></code> and <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-source-element" id="ref-for-the-source-element①">source</a></code>.</p>
+     </ul>
+     <p>We further limit this category in <a href="#should-block-fetch">§ 4.4 Should fetching request be blocked as mixed content?</a> by force-failing any CORS-enabled
+    request. This means, for example, that mixed content images loaded via <code>&lt;img crossorigin ...></code> will be blocked. This is a good example of the general principle that content falls into this
+    category <em>only</em> when it is too widely used to be blocked outright. The Working Group
+    intends to carve out more blockable subsets as time goes on.</p>
+    </section>
+    <section>
+     <h3 class="heading settled" data-level="3.2" id="category-blockable"><span class="secno">3.2. </span><span class="content">Blockable Content</span><a class="self-link" href="#category-blockable"></a></h3>
+     <p>Any mixed content that is not <a data-link-type="dfn" href="#optionally-blockable-mixed-content" id="ref-for-optionally-blockable-mixed-content①">optionally-blockable</a> as defined above is considered to be <dfn class="dfn-paneled" data-dfn-type="dfn" data-export data-local-lt="blockable" data-lt="blockable mixed content" id="blockable-mixed-content">blockable</dfn>. Typical examples
+    of this kind of content include scripts, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#plugin" id="ref-for-plugin">plugin</a> data, data requested via <code class="idl"><a data-link-type="idl" href="https://xhr.spec.whatwg.org/#xmlhttprequest" id="ref-for-xmlhttprequest">XMLHttpRequest</a></code>, and so on.</p>
+     <p class="note" role="note"><span>Note:</span> <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#navigation-request" id="ref-for-navigation-request">Navigation requests</a> might target <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#top-level-browsing-context" id="ref-for-top-level-browsing-context">top-level browsing contexts</a>; these are not
+    considered mixed content. See <a href="#should-block-fetch">§ 4.4 Should fetching request be blocked as mixed content?</a> for details.</p>
+     <p class="note" role="note"><span>Note:</span> Note that requests made on behalf of a plugin are blockable. We recognize, however, that
+    user agents aren’t always in a position to mediate these requests. NPAPI plugins, for instance,
+    often have direct network access, and can generally bypass the user agent entirely. We recommend
+    that user agents block these requests when possible, and that plugin vendors implement mixed
+    content checking themselves to mitigate the risks o utlined in this document.</p>
+    </section>
+   </section>
+   <section>
+    <h2 class="heading settled" data-level="4" id="algorithms"><span class="secno">4. </span><span class="content">Algorithms</span><a class="self-link" href="#algorithms"></a></h2>
+    <section>
+     <h3 class="heading settled" data-level="4.1" id="upgrade-algorithm"><span class="secno">4.1. </span><span class="content">Upgrade <var>request</var> to an <i lang="la">a priori</i> authenticated URL as mixed content, if appropriate</span><a class="self-link" href="#upgrade-algorithm"></a></h3>
      <p class="note" role="note"><span>Note:</span> The Fetch specification will hook into this algorithm to upgrade optionally-blockable
     mixed content to HTTPS.</p>
-     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request">Request</a> <var>request</var>, this algorithm will rewrite
-    its <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url">url</a> if the request is deemed to be optionally-blockable mixed content,
+     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③">Request</a> <var>request</var>, this algorithm will rewrite
+    its <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url①">url</a> if the request is deemed to be optionally-blockable mixed content,
     via the following algorithm:</p>
      <ol>
       <li>
         If one or more of the following conditions is met, return without modifying <var>request</var>: 
        <ol>
-        <li> <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url①">url</a> is an <a href="https://www.w3.org/TR/mixed-content/#a-priori-authenticated-url">Mixed Content §a-priori-authenticated-url</a>. 
-        <li> <a href="https://www.w3.org/TR/mixed-content/#categorize-settings-object">Mixed Content §categorize-settings-object</a> returns "<code>Does Not Restrict Mixed Security
+        <li> <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url②">url</a> is an <a data-link-type="dfn" href="#a-priori-authenticated-url" id="ref-for-a-priori-authenticated-url②"><i lang="la">a priori</i> authenticated URLs</a> 
+        <li> <a href="#categorize-settings-object">§ 4.3 Does settings prohibit mixed security contexts?</a> returns "<code>Does Not Restrict Mixed Security
             Contents</code>" when applied to <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client">client</a>. 
         <li> <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-mode" id="ref-for-concept-request-mode">mode</a> is <code>CORS</code>. 
-        <li> <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination">destination</a> is not "<code>image</code>",
+        <li> <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination③">destination</a> is not "<code>image</code>",
             "<code>audio</code>", or "<code>video</code>". 
-        <li> <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination①">destination</a> is "<code>image</code>"
-            and <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-initiator" id="ref-for-concept-request-initiator">initiator</a> is "<code>imageset</code>". 
+        <li> <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination④">destination</a> is "<code>image</code>"
+            and <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-initiator" id="ref-for-concept-request-initiator①">initiator</a> is "<code>imageset</code>". 
        </ol>
       <li>
-        If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url②">url</a>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme">scheme</a> is <code>http</code>,
-        set <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url③">url</a>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme①">scheme</a> to <code>https</code>, and return. 
+        If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url③">url</a>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme②">scheme</a> is <code>http</code>,
+        set <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url④">url</a>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme③">scheme</a> to <code>https</code>, and return. 
        <p class="note" role="note"><span>Note:</span> Per <a data-link-type="biblio" href="#biblio-url">[url]</a>, we do not modify the port because it will be set to null when the scheme
         is <code>http</code>, and interpreted as 443 once the scheme is changed
         to <code>https</code></p>
      </ol>
     </section>
     <section>
-     <h3 class="heading settled" data-level="3.2" id="modifications"><span class="secno">3.2. </span><span class="content">Modifications to existing algorithms</span><a class="self-link" href="#modifications"></a></h3>
+     <h3 class="heading settled" data-level="4.2" id="existing-mix-algorithms"><span class="secno">4.2. </span><span class="content">Existing Mixed Content Algorithms and Modifications</span><a class="self-link" href="#existing-mix-algorithms"></a></h3>
      <p class="note" role="note"><span>Note:</span> This section specifies modifications to existing mixed content algorithms to ignore the
     distinction between optionally-blockable and blockable mixed content, since all
-    optionally-blockable mixed content will now be autoupgraded.</p>
-     <p><a href="https://www.w3.org/TR/mixed-content/#should-block-fetch">Mixed Content §should-block-fetch</a> should be modified to remove Steps 3, 4, and 5, replacing
-    them with a single step "Return <strong>blocked</strong>".</p>
-     <p><a href="https://www.w3.org/TR/mixed-content/#should-block-response">Mixed Content §should-block-response</a> should be modified to remove Steps 2, 3, and 4,
-    replacing them with a single step "Return <strong>blocked</strong>".</p>
+    optionally-blockable mixed content will now be autoupgraded. <a href="https://www.w3.org/TR/mixed-content/#should-block-fetch">Mixed Content §should-block-fetch</a> and <a href="https://www.w3.org/TR/mixed-content/#should-block-response">Mixed Content §should-block-response</a> are
+    replaced by the versions below, while <a href="https://www.w3.org/TR/mixed-content/#categorize-settings-object">Mixed Content §categorize-settings-object</a> is left
+    unmodified (but included below since this will replace the <a data-link-type="biblio" href="#biblio-mixed-content">[mixed-content]</a> spec).</p>
+     <p>section></p>
+     <h3 class="heading settled" data-level="4.3" id="categorize-settings-object"><span class="secno">4.3. </span><span class="content"> Does <var>settings</var> prohibit mixed security contexts? </span><a class="self-link" href="#categorize-settings-object"></a></h3>
+     <p>Both documents and workers have <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object" id="ref-for-environment-settings-object">environment settings objects</a> which
+    may be examined according to the following algorithm in order to determine
+    whether they restrict mixed content. This algorithm returns "<code>Prohibits Mixed Security Contexts</code>" or "<code>Does Not Prohibit Mixed Security Contexts</code>",
+    as appropriate.</p>
+     <p>Given an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object" id="ref-for-environment-settings-object①">environment settings object</a> (<var>settings</var>):</p>
+     <ol>
+      <li data-md>
+       <p>If <var>settings</var>’ <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#https-state" id="ref-for-https-state">HTTPS state</a> is not "<code>none</code>", then return
+  "<code>Prohibits Mixed Security Contexts</code>".</p>
+      <li data-md>
+       <p>If <var>settings</var> has a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-document" id="ref-for-responsible-document">responsible document</a> <var>document</var>, then:</p>
+       <ol>
+        <li data-md>
+         <p>While <var>document</var> has an <a data-link-type="dfn" href="#embedding-document" id="ref-for-embedding-document">embedding document</a>:</p>
+         <ol>
+          <li data-md>
+           <p>Set <var>document</var> to <var>document</var>’s <a data-link-type="dfn" href="#embedding-document" id="ref-for-embedding-document①">embedding document</a>.</p>
+          <li data-md>
+           <p>Let <var>embedder settings</var> be <var>document</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object">global object</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object" id="ref-for-relevant-settings-object">relevant settings object</a>.</p>
+          <li data-md>
+           <p>If <var>embedder settings</var>’ <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#https-state" id="ref-for-https-state①">HTTPS state</a> is not "<code>None</code>",
+  then return "<code>Prohibits Mixed Security Contexts</code>".</p>
+         </ol>
+       </ol>
+      <li data-md>
+       <p>Return "<code>Does Not Restrict Mixed Security Contexts</code>".</p>
+     </ol>
+     <div class="note" role="note">
+       If a document has an <a data-link-type="dfn" href="#embedding-document" id="ref-for-embedding-document②">embedding document</a>, a user agent needs to
+      check not only the document itself, but also the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#top-level-browsing-context" id="ref-for-top-level-browsing-context①">top-level browsing
+      context</a> in which the document is nested, as that is the context
+      which controls the user’s expectations regarding the security status of
+      the resource she’s loaded. For example: 
+      <div class="example" id="example-4c853e3e"><a class="self-link" href="#example-4c853e3e"></a> <code>http://a.com</code> loads <code>http://evil.com</code>. The
+        insecure request will be allowed, as <code>a.com</code> was not loaded
+        over a secure connection. </div>
+      <div class="example" id="example-c38c3226"><a class="self-link" href="#example-c38c3226"></a> <code>https://a.com</code> loads <code>http://evil.com</code>. The
+        insecure request will be blocked, as <code>a.com</code> was loaded over
+        a secure connection. </div>
+      <div class="example" id="example-1ec6834e"><a class="self-link" href="#example-1ec6834e"></a> <code>http://a.com</code> frames <code>https://b.com</code>, which
+        loads <code>http://evil.com</code>. In this case, the insecure request
+        to <code>evil.com</code> will be blocked, as <code>b.com</code> was
+        loaded over a secure connection, even though <code>a.com</code> was not. </div>
+      <div class="example" id="example-202f3835"><a class="self-link" href="#example-202f3835"></a> <code>https://a.com</code> frames a <code>data:</code> URL, which loads <code>http://evil.com</code>. In this case, the insecure request to <code>evil.com</code> will be blocked, as <code>a.com</code> was loaded
+        over a secure connection, even though the framed <code>data:</code> URL
+        would not block mixed content if loaded in a top-level context. </div>
+     </div>
     </section>
     <section>
-     <h2 class="heading settled" data-level="4" id="integration"><span class="secno">4. </span><span class="content">Integrations</span><a class="self-link" href="#integration"></a></h2>
-     <h3 class="heading settled" data-level="4.1" id="fetch"><span class="secno">4.1. </span><span class="content">Modifications to Fetch</span><a class="self-link" href="#fetch"></a></h3>
-     <p><a href="https://fetch.spec.whatwg.org/#main-fetch">Fetch Standard §4.1 Main fetch</a> should be modified to call <a href="#upgrade-algorithm">§ 3.1 Upgrade request to an a priori
+     <h3 class="heading settled" data-level="4.4" id="should-block-fetch"><span class="secno">4.4. </span><span class="content"> Should fetching <var>request</var> be blocked as mixed content? </span><a class="self-link" href="#should-block-fetch"></a></h3>
+     <p class="note" role="note"><span>Note:</span> The Fetch specification hooks into this algorithm to determine whether
+    a request should be entirely blocked (e.g. because the request is for <a data-link-type="dfn" href="#blockable-mixed-content" id="ref-for-blockable-mixed-content①">blockable</a> content, and we can <em>assume</em> that it won’t be
+    loaded over a secure connection).</p>
+     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④">Request</a> <var>request</var>, a user agent determines
+    whether the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤">Request</a> <var>request</var> should proceed or not via the
+    following algorithm:</p>
+     <ol>
+      <li>
+        Return <strong>allowed</strong> if one or more of the following
+        conditions are met: 
+       <ol>
+        <li> <a href="#categorize-settings-object">§ 4.3 Does settings prohibit mixed security contexts?</a> returns "<code>Does Not Restrict Mixed Security Contexts</code>" when applied to <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client①">client</a>. 
+        <li> <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url⑤">url</a> is <a data-link-type="dfn" href="#a-priori-authenticated-url" id="ref-for-a-priori-authenticated-url③"><i lang="la">a priori</i> authenticated</a>. 
+        <li> The user agent has been instructed to allow <a data-link-type="dfn" href="#mixed-content" id="ref-for-mixed-content③">mixed content</a>, as
+            described in <a href="#requirements-user-controls">§ 8.2 User Controls</a>). 
+        <li>
+          <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination⑤">destination</a> is
+            "<code>document</code>", and <var>request</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-target-browsing-context" id="ref-for-concept-environment-target-browsing-context">target browsing
+            context</a> has no <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#parent-browsing-context" id="ref-for-parent-browsing-context">parent browsing context</a>. 
+         <p class="note" role="note"><span>Note:</span> We exclude top-level navigations from mixed content checks,
+            but user agents MAY choose to enforce mixed content checks on
+            insecure form submissions (see <a href="#requirements-forms">§ 8.1 Form Submission</a>).</p>
+       </ol>
+      <li> Return <strong>blocked</strong>. 
+     </ol>
+    </section>
+    <section>
+     <h3 class="heading settled" data-level="4.5" id="should-block-response"><span class="secno">4.5. </span><span class="content"> Should <var>response</var> to <var>request</var> be blocked as mixed
+      content? </span><a class="self-link" href="#should-block-response"></a></h3>
+     <p class="note" role="note"><span>Note:</span> <a href="#should-block-fetch">If a request proceeds</a>, we still
+    might want to block the response based on the state of the connection
+    that generated the response (e.g. because the request is <a data-link-type="dfn" href="#blockable-mixed-content" id="ref-for-blockable-mixed-content②">blockable</a>,
+    but the connection is <a data-link-type="dfn" href="#unauthenticated-response" id="ref-for-unauthenticated-response①">unauthenticated</a>), and we also need to ensure
+    that a Service Worker doesn’t accidentally return an <a data-link-type="dfn" href="#unauthenticated-response" id="ref-for-unauthenticated-response②">unauthenticated
+    response</a> for a <a data-link-type="dfn" href="#blockable-mixed-content" id="ref-for-blockable-mixed-content③">blockable</a> request. This algorithm is used to make
+    that determination.</p>
+     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥">request</a> <var>request</var> and <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②">response</a> <var>response</var>, the user agent determines what response should be
+    returned via the following algorithm:</p>
+     <ol>
+      <li>
+        Return <strong>allowed</strong> if one or more of the following
+        conditions are met: 
+       <ol>
+        <li> <a href="#categorize-settings-object">§ 4.3 Does settings prohibit mixed security contexts?</a> returns <code>Does Not Restrict
+            Mixed Content</code> when applied to <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client②">client</a>. 
+        <li> <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-https-state" id="ref-for-concept-response-https-state①">HTTPS state</a> is <code>modern</code>. 
+        <li> The user agent has been instructed to allow <a data-link-type="dfn" href="#mixed-content" id="ref-for-mixed-content④">mixed content</a>, as
+            described in <a href="#requirements-user-controls">§ 8.2 User Controls</a>). 
+        <li>
+          <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination⑥">destination</a> is
+            "<code>document</code>", and <var>request</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-target-browsing-context" id="ref-for-concept-environment-target-browsing-context①">target browsing
+            context</a> has no <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#parent-browsing-context" id="ref-for-parent-browsing-context①">parent browsing context</a>. 
+         <p class="note" role="note"><span>Note:</span> We exclude top-level navigations from mixed content checks,
+            but user agents MAY choose to enforce mixed content checks on
+            insecure form submissions (see <a href="#requirements-forms">§ 8.1 Form Submission</a>).</p>
+       </ol>
+      <li>Return <strong>blocked</strong>.
+     </ol>
+    </section>
+   </section>
+   <section>
+    <h2 class="heading settled" data-level="5" id="integration"><span class="secno">5. </span><span class="content">Integrations</span><a class="self-link" href="#integration"></a></h2>
+    <h3 class="heading settled" data-level="5.1" id="fetch"><span class="secno">5.1. </span><span class="content">Modifications to Fetch</span><a class="self-link" href="#fetch"></a></h3>
+    <p><a href="https://fetch.spec.whatwg.org/#main-fetch">Fetch Standard §4.1 Main fetch</a> should be modified to call <a href="#upgrade-algorithm">§ 4.1 Upgrade request to an a priori
     authenticated URL as mixed content, if appropriate</a> on <var>request</var> between steps 3 and 4. That is, optionally-blockable mixed content should be autoupgraded to HTTPS
   before applying mixed content blocking.</p>
-    </section>
-    <section>
-     <h2 class="heading settled" data-level="5" id="obsolescences"><span class="secno">5. </span><span class="content">Obsolescences</span><a class="self-link" href="#obsolescences"></a></h2>
-     <h3 class="heading settled" data-level="5.1" id="block-all-mixed-content"><span class="secno">5.1. </span><span class="content"><code>block-all-mixed-content</code></span><a class="self-link" href="#block-all-mixed-content"></a></h3>
-     <p>This specification renders the <a href="https://www.w3.org/TR/mixed-content/#block-all-mixed-content">Mixed Content §block-all-mixed-content</a> CSP directive obsolete,
+    <h3 class="heading settled" data-level="5.2" id="html"><span class="secno">5.2. </span><span class="content">Modifications to HTML</span><a class="self-link" href="#html"></a></h3>
+    <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#process-a-navigate-response" id="ref-for-process-a-navigate-response">Process a navigate response</a> should be modified as follows. Step 3 should abort the download
+  and return if <var>source</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#active-document" id="ref-for-active-document">active document</a>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document-url" id="ref-for-concept-document-url">url</a> is an <a data-link-type="dfn" href="#a-priori-authenticated-url" id="ref-for-a-priori-authenticated-url④"><i lang="la">a priori</i> authenticated URLs</a> and any URL
+  in <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-url-list" id="ref-for-concept-response-url-list">URL list</a> is not an <a data-link-type="dfn" href="#a-priori-authenticated-url" id="ref-for-a-priori-authenticated-url⑤"><i lang="la">a priori</i> authenticated URLs</a>.</p>
+    <p>A similar change should be made to <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/links.html#downloading-hyperlinks" id="ref-for-downloading-hyperlinks">downloads a hyperlink</a>. In this algorithm, step 6.2
+  should be modified to return (aborting the download) if <var>subject</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-node-document" id="ref-for-concept-node-document">node
+  document</a>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document-url" id="ref-for-concept-document-url①">url</a> is an <a data-link-type="dfn" href="#a-priori-authenticated-url" id="ref-for-a-priori-authenticated-url⑥"><i lang="la">a priori</i> authenticated URLs</a> and
+  any URL in <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-url-list" id="ref-for-concept-response-url-list①">URL list</a> is not an <a data-link-type="dfn" href="#a-priori-authenticated-url" id="ref-for-a-priori-authenticated-url⑦"><i lang="la">a priori</i> authenticated URLs</a> (where <var>response</var> is the result of
+  fetching <var>request</var>).</p>
+    <p class="note" role="note"><span>Note:</span> Downloads are not autoupgraded like other types of mixed content, because the user agent
+  does not always know before requesting a resource that it will be downloaded.</p>
+    <p class="note" role="note"><span>Note:</span> Resources are downloaded before the user agent decides whether to abort them based on an
+  insecure connection. Sensitive information may therefore traverse the network even though the user
+  agent eventually blocks the download. This is generally unavoidable because the user agent may not
+  know that a resource is to be downloaded until it receives the final response, but by blocking the
+  resource, user agents will encourage website operators to serve downloads over secure connections.</p>
+   </section>
+   <section>
+    <h2 class="heading settled" data-level="6" id="obsolescences"><span class="secno">6. </span><span class="content">Obsolescences</span><a class="self-link" href="#obsolescences"></a></h2>
+    <h3 class="heading settled" data-level="6.1" id="block-all-mixed-content"><span class="secno">6.1. </span><span class="content"><code>block-all-mixed-content</code></span><a class="self-link" href="#block-all-mixed-content"></a></h3>
+    <p>This specification renders the <a href="https://www.w3.org/TR/mixed-content/#block-all-mixed-content">Mixed Content §block-all-mixed-content</a> CSP directive obsolete,
   because all mixed content is now blocked if it can’t be autoupgraded.</p>
-     <p class="note" role="note"><span>Note:</span> The <code>upgrade-insecure-requests</code> (<a data-link-type="biblio" href="#biblio-upgrade-insecure-requests">[upgrade-insecure-requests]</a>) directive is not
+    <p class="note" role="note"><span>Note:</span> The <code>upgrade-insecure-requests</code> (<a data-link-type="biblio" href="#biblio-upgrade-insecure-requests">[upgrade-insecure-requests]</a>) directive is not
   obsolete because it allows developers to upgrade blockable content. This specification only
   upgrades optionally-blockable content by default.</p>
-    </section>
-    <section>
-     <h2 class="heading settled" data-level="6" id="security-considerations"><span class="secno">6. </span><span class="content">Security and Privacy Considerations</span><a class="self-link" href="#security-considerations"></a></h2>
-     <p>Overall, autoupgrading optionally-blockable mixed content is expected to be security- and
+    <h3 class="heading settled" data-level="6.2" id="mixed-content-1"><span class="secno">6.2. </span><span class="content"><code>Mixed Content</code></span><a class="self-link" href="#mixed-content-1"></a></h3>
+    <p>This specification renders the <a data-link-type="biblio" href="#biblio-mixed-content">[mixed-content]</a> specification obsolete,
+  and replaces it.</p>
+   </section>
+   <section>
+    <h2 class="heading settled" data-level="7" id="websockets-integration"><span class="secno">7. </span><span class="content">Modifications to WebSockets</span><a class="self-link" href="#websockets-integration"></a></h2>
+    <p>The <a href="https://www.w3.org/TR/websockets/#the-websocket-interface"><code>WebSocket()</code> constructor algorithm</a> <a data-link-type="biblio" href="#biblio-websockets">[WEBSOCKETS]</a> is modified as follows:</p>
+    <ul>
+     <li> Remove the current step 2. 
+    </ul>
+    <p class="note" role="note"><span>Note:</span> This suggestion is filed as <a href="https://www.w3.org/Bugs/Public/show_bug.cgi?id=28841">bug #28841</a> against <a data-link-type="biblio" href="#biblio-websockets">[WEBSOCKETS]</a>.</p>
+    <p>The <a href="http://tools.ietf.org/html/rfc6455#section-4.1">Establish a
+  WebSocket Connection algorithm</a> <a data-link-type="biblio" href="#biblio-rfc6455">[RFC6455]</a> is modified as follows:</p>
+    <ol>
+     <li data-md>
+      <p>After the current step 1, perform the following step:</p>
+      <ol>
+       <li data-md>
+        <p>If <var>secure</var> is <code>false</code>, and the algorithm in <a href="#categorize-settings-object">§ 4.3 Does settings prohibit mixed security contexts?</a> returns "<code>Restricts Mixed Security Context</code>" when applied to <var>client</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object①">global object</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object" id="ref-for-relevant-settings-object①">relevant settings object</a>, then the client MUST <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6455#section-7.1.7" id="ref-for-section-7.1.7">fail the
+  WebSocket connection</a> and abort the connection <a data-link-type="biblio" href="#biblio-rfc6455">[RFC6455]</a>.</p>
+      </ol>
+     <li data-md>
+      <p>After the current step 5, perform the following step:</p>
+      <ol start="6">
+       <li data-md>
+        <p>If <var>secure</var> is <code>true</code>, and the TLS handshake performed in step 5
+  results in an HTTPS state of "<code>deprecated</code>", then the client MUST <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6455#section-7.1.7" id="ref-for-section-7.1.7①">fail the WebSocket connection</a> and abort the connection <a data-link-type="biblio" href="#biblio-rfc6455">[RFC6455]</a>.</p>
+      </ol>
+    </ol>
+    <p class="note" role="note"><span>Note:</span> Filed as <a href="http://www.rfc-editor.org/errata_search.php?rfc=6455&amp;eid=4398">errata #4398</a> against <a data-link-type="biblio" href="#biblio-rfc6455">[RFC6455]</a>.</p>
+    <p>These changes together mean that we’ll no longer throw a <code>SecurityError</code> exception directly upon constructing a WebSocket object, but will instead rely
+  upon blocking the connection and triggering the <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6455#section-7.1.7" id="ref-for-section-7.1.7②">fail the WebSocket
+  connection</a> algorithm, which developers can catch by hooking a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/web-sockets.html#websocket" id="ref-for-websocket">WebSocket</a></code> object’s <code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/websockets/#handler-websocket-onerror" id="ref-for-handler-websocket-onerror">onerror</a></code> handler. This is consistent with
+  the behavior of <code class="idl"><a data-link-type="idl" href="https://xhr.spec.whatwg.org/#xmlhttprequest" id="ref-for-xmlhttprequest①">XMLHttpRequest</a></code>, <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/server-sent-events.html#eventsource" id="ref-for-eventsource">EventSource</a></code>, and <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#dom-global-fetch" id="ref-for-dom-global-fetch">fetch()</a></code>.</p>
+   </section>
+   <section>
+    <h2 class="heading settled" data-level="8" id="security-considerations"><span class="secno">8. </span><span class="content">Security and Privacy Considerations</span><a class="self-link" href="#security-considerations"></a></h2>
+    <p>Overall, autoupgrading optionally-blockable mixed content is expected to be security- and
   privacy-positive, by protecting more user traffic from network eavesdropping and tampering.</p>
-     <p>There is a risk of introducing a security or privacy issue in a webpage by loading a resource that
+    <p>There is a risk of introducing a security or privacy issue in a webpage by loading a resource that
   the developer did not intend. For example, suppose that a website includes an innocuous image
   from <code>http://www.example.com/image.jpg</code>, and for some
   reason <code>https://www.example.com/image.jpg</code> redirects to a tracking site. The browser
@@ -414,10 +714,35 @@ pre .property::before, pre .property::after {
   autoupgrading only optionally-blockable content, not blockable content as well. Blockable content
   could present more risk, for example the risk of loading an out-of-date and vulnerable JavaScript
   library.</p>
-    </section>
     <section>
-     <h2 class="heading settled" data-level="7" id="acknowledgements"><span class="secno">7. </span><span class="content">Acknowledgements</span><a class="self-link" href="#acknowledgements"></a></h2>
+     <h3 class="heading settled" data-level="8.1" id="requirements-forms"><span class="secno">8.1. </span><span class="content">Form Submission</span><a class="self-link" href="#requirements-forms"></a></h3>
+     <p>If <a href="#categorize-settings-object">§ 4.3 Does settings prohibit mixed security contexts?</a> returns <code>Restricts Mixed Content</code> when applied to a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①">Document</a></code>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object" id="ref-for-relevant-settings-object②">relevant settings object</a>, then a user agent MAY choose to warn users of the
+    presence of one or more <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/forms.html#the-form-element" id="ref-for-the-form-element">form</a></code> elements with <a data-link-type="element-attr" href="https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fs-action" id="ref-for-attr-fs-action">action</a> attributes whose
+    values are not <a data-link-type="dfn" href="#a-priori-authenticated-url" id="ref-for-a-priori-authenticated-url⑧"><i lang="la">a priori</i> authenticated URLs</a></p>
+     <p>A user agent MAY choose to warn users on submission of a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/forms.html#the-form-element" id="ref-for-the-form-element①">form</a></code> element with <a data-link-type="element-attr" href="https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fs-action" id="ref-for-attr-fs-action①">action</a> attributes whose values are not <a data-link-type="dfn" href="#a-priori-authenticated-url" id="ref-for-a-priori-authenticated-url⑨"><i lang="la">a priori</i> authenticated URLs</a> and allow users to abort the submission.</p>
+     <p>Further, a user agent MAY treat form submissions from such a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document②">Document</a></code> as a <a data-link-type="dfn" href="#blockable-mixed-content" id="ref-for-blockable-mixed-content④">blockable</a> request, even if the submission occurs in the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#top-level-browsing-context" id="ref-for-top-level-browsing-context②">top-level browsing context</a>.</p>
     </section>
+   </section>
+   <section>
+    <h3 class="heading settled" data-level="8.2" id="requirements-user-controls"><span class="secno">8.2. </span><span class="content">User Controls</span><a class="self-link" href="#requirements-user-controls"></a></h3>
+    <p>A user agent MAY offer users the ability to directly decide whether or not
+    to treat <strong>all</strong> <a data-link-type="dfn" href="#mixed-content" id="ref-for-mixed-content⑤">mixed content</a> as <a data-link-type="dfn" href="#blockable-mixed-content" id="ref-for-blockable-mixed-content⑤">blockable</a> (meaning that even <a data-link-type="dfn" href="#optionally-blockable-mixed-content" id="ref-for-optionally-blockable-mixed-content②">optionally-blockable</a> mixed content would be
+    blocked).</p>
+    <p class="note" role="note"><span>Note:</span> It is <em>strongly recommended</em> that users take advantage of such
+    an option if provided.</p>
+    <p>A user agent MAY offer users the ability to override its decision to block <a data-link-type="dfn" href="#blockable-mixed-content" id="ref-for-blockable-mixed-content⑥">blockable</a> mixed content on a particular page.</p>
+    <p class="note" role="note"><span>Note:</span> Practically, a user agent probably can’t get away with not offering
+    such a back door. That said, allowing mixed script is in particular a very
+    dangerous option, and each user agent <a href="http://tools.ietf.org/html/rfc6919#section-3">REALLY SHOULD NOT</a> <a data-link-type="biblio" href="#biblio-rfc6919">[RFC6919]</a> present such a choice to users without careful consideration and
+    communication of the risk involved.</p>
+    <p>A user agent MAY offer users the ability to override its decision to
+    automatically upgrade <a data-link-type="dfn" href="#optionally-blockable-mixed-content" id="ref-for-optionally-blockable-mixed-content③">optionally-blockable</a> mixed content on a
+    particular page.</p>
+    <p>Any such controls offered by a user agent MUST also be offered through
+    accessibility APIs for users of assistive technologies.</p>
+   </section>
+   <section>
+    <h2 class="heading settled" data-level="9" id="acknowledgements"><span class="secno">9. </span><span class="content">Acknowledgements</span><a class="self-link" href="#acknowledgements"></a></h2>
    </section>
   </main>
   <h2 class="no-ref no-num heading settled" id="conformance"><span class="content">Conformance</span><a class="self-link" href="#conformance"></a></h2>
@@ -453,90 +778,510 @@ pre .property::before, pre .property::after {
     are encouraged to optimize.</p>
 <script src="https://www.w3.org/scripts/TR/2016/fixup.js"></script>
   <h2 class="no-num no-ref heading settled" id="index"><span class="content">Index</span><a class="self-link" href="#index"></a></h2>
+  <h3 class="no-num no-ref heading settled" id="index-defined-here"><span class="content">Terms defined by this specification</span><a class="self-link" href="#index-defined-here"></a></h3>
+  <ul class="index">
+   <li><a href="#a-priori-authenticated-url">a priori authenticated</a><span>, in §2</span>
+   <li><a href="#a-priori-authenticated-url">a priori authenticated URL</a><span>, in §2</span>
+   <li><a href="#blockable-mixed-content">blockable</a><span>, in §3.2</span>
+   <li><a href="#blockable-mixed-content">blockable mixed content</a><span>, in §3.2</span>
+   <li><a href="#embedding-document">embedding document</a><span>, in §2</span>
+   <li><a href="#mixed-content">mixed</a><span>, in §2</span>
+   <li><a href="#mixed-content">mixed content</a><span>, in §2</span>
+   <li><a href="#mixed-download">mixed download</a><span>, in §2</span>
+   <li><a href="#optionally-blockable-mixed-content">optionally-blockable</a><span>, in §3.1</span>
+   <li><a href="#optionally-blockable-mixed-content">optionally-blockable mixed content</a><span>, in §3.1</span>
+   <li><a href="#unauthenticated-response">unauthenticated</a><span>, in §2</span>
+   <li><a href="#unauthenticated-response">unauthenticated response</a><span>, in §2</span>
+  </ul>
+  <aside class="dfn-panel" data-for="term-for-propdef-background-image">
+   <a href="https://www.w3.org/TR/css3-background/#propdef-background-image">https://www.w3.org/TR/css3-background/#propdef-background-image</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-propdef-background-image">3.1. Optionally-blockable Content</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-propdef-border-image">
+   <a href="https://www.w3.org/TR/css3-background/#propdef-border-image">https://www.w3.org/TR/css3-background/#propdef-border-image</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-propdef-border-image">3.1. Optionally-blockable Content</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-document">
+   <a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-document">2. Key Concepts and Terminology</a>
+    <li><a href="#ref-for-document①">8.1. Form Submission</a> <a href="#ref-for-document②">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-concept-node-document">
+   <a href="https://dom.spec.whatwg.org/#concept-node-document">https://dom.spec.whatwg.org/#concept-node-document</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-concept-node-document">5.2. Modifications to HTML</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-concept-document-url">
+   <a href="https://dom.spec.whatwg.org/#concept-document-url">https://dom.spec.whatwg.org/#concept-document-url</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-concept-document-url">5.2. Modifications to HTML</a> <a href="#ref-for-concept-document-url①">(2)</a>
+   </ul>
+  </aside>
   <aside class="dfn-panel" data-for="term-for-concept-request-client">
    <a href="https://fetch.spec.whatwg.org/#concept-request-client">https://fetch.spec.whatwg.org/#concept-request-client</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-request-client">3.1. Upgrade request to an a priori
+    <li><a href="#ref-for-concept-request-client">4.1. Upgrade request to an a priori
     authenticated URL as mixed content, if appropriate</a>
+    <li><a href="#ref-for-concept-request-client①">4.4. 
+      Should fetching request be blocked as mixed content? </a>
+    <li><a href="#ref-for-concept-request-client②">4.5. 
+      Should response to request be blocked as mixed
+      content? </a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-request-destination">
    <a href="https://fetch.spec.whatwg.org/#concept-request-destination">https://fetch.spec.whatwg.org/#concept-request-destination</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-request-destination">3.1. Upgrade request to an a priori
-    authenticated URL as mixed content, if appropriate</a> <a href="#ref-for-concept-request-destination①">(2)</a>
+    <li><a href="#ref-for-concept-request-destination">3.1. Optionally-blockable Content</a> <a href="#ref-for-concept-request-destination①">(2)</a> <a href="#ref-for-concept-request-destination②">(3)</a>
+    <li><a href="#ref-for-concept-request-destination③">4.1. Upgrade request to an a priori
+    authenticated URL as mixed content, if appropriate</a> <a href="#ref-for-concept-request-destination④">(2)</a>
+    <li><a href="#ref-for-concept-request-destination⑤">4.4. 
+      Should fetching request be blocked as mixed content? </a>
+    <li><a href="#ref-for-concept-request-destination⑥">4.5. 
+      Should response to request be blocked as mixed
+      content? </a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-dom-global-fetch">
+   <a href="https://fetch.spec.whatwg.org/#dom-global-fetch">https://fetch.spec.whatwg.org/#dom-global-fetch</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-global-fetch">7. Modifications to WebSockets</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-concept-response-https-state">
+   <a href="https://fetch.spec.whatwg.org/#concept-response-https-state">https://fetch.spec.whatwg.org/#concept-response-https-state</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-concept-response-https-state">2. Key Concepts and Terminology</a>
+    <li><a href="#ref-for-concept-response-https-state①">4.5. 
+      Should response to request be blocked as mixed
+      content? </a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-request-initiator">
    <a href="https://fetch.spec.whatwg.org/#concept-request-initiator">https://fetch.spec.whatwg.org/#concept-request-initiator</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-request-initiator">3.1. Upgrade request to an a priori
+    <li><a href="#ref-for-concept-request-initiator">3.1. Optionally-blockable Content</a>
+    <li><a href="#ref-for-concept-request-initiator①">4.1. Upgrade request to an a priori
     authenticated URL as mixed content, if appropriate</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-request-mode">
    <a href="https://fetch.spec.whatwg.org/#concept-request-mode">https://fetch.spec.whatwg.org/#concept-request-mode</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-request-mode">3.1. Upgrade request to an a priori
+    <li><a href="#ref-for-concept-request-mode">4.1. Upgrade request to an a priori
     authenticated URL as mixed content, if appropriate</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-navigation-request">
+   <a href="https://fetch.spec.whatwg.org/#navigation-request">https://fetch.spec.whatwg.org/#navigation-request</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-navigation-request">3.2. Blockable Content</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-request">
    <a href="https://fetch.spec.whatwg.org/#concept-request">https://fetch.spec.whatwg.org/#concept-request</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-request">3.1. Upgrade request to an a priori
+    <li><a href="#ref-for-concept-request">2. Key Concepts and Terminology</a> <a href="#ref-for-concept-request①">(2)</a> <a href="#ref-for-concept-request②">(3)</a>
+    <li><a href="#ref-for-concept-request③">4.1. Upgrade request to an a priori
     authenticated URL as mixed content, if appropriate</a>
+    <li><a href="#ref-for-concept-request④">4.4. 
+      Should fetching request be blocked as mixed content? </a> <a href="#ref-for-concept-request⑤">(2)</a>
+    <li><a href="#ref-for-concept-request⑥">4.5. 
+      Should response to request be blocked as mixed
+      content? </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-url">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-url">https://fetch.spec.whatwg.org/#concept-request-url</a><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="term-for-concept-response">
+   <a href="https://fetch.spec.whatwg.org/#concept-response">https://fetch.spec.whatwg.org/#concept-response</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-request-url">3.1. Upgrade request to an a priori
-    authenticated URL as mixed content, if appropriate</a> <a href="#ref-for-concept-request-url①">(2)</a> <a href="#ref-for-concept-request-url②">(3)</a> <a href="#ref-for-concept-request-url③">(4)</a>
+    <li><a href="#ref-for-concept-response">2. Key Concepts and Terminology</a> <a href="#ref-for-concept-response①">(2)</a>
+    <li><a href="#ref-for-concept-response②">4.5. 
+      Should response to request be blocked as mixed
+      content? </a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-concept-response-url">
+   <a href="https://fetch.spec.whatwg.org/#concept-response-url">https://fetch.spec.whatwg.org/#concept-response-url</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-concept-response-url">2. Key Concepts and Terminology</a> <a href="#ref-for-concept-response-url①">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-concept-response-url-list">
+   <a href="https://fetch.spec.whatwg.org/#concept-response-url-list">https://fetch.spec.whatwg.org/#concept-response-url-list</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-concept-response-url-list">5.2. Modifications to HTML</a> <a href="#ref-for-concept-response-url-list①">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-eventsource">
+   <a href="https://html.spec.whatwg.org/multipage/server-sent-events.html#eventsource">https://html.spec.whatwg.org/multipage/server-sent-events.html#eventsource</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-eventsource">7. Modifications to WebSockets</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-websocket">
+   <a href="https://html.spec.whatwg.org/multipage/web-sockets.html#websocket">https://html.spec.whatwg.org/multipage/web-sockets.html#websocket</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-websocket">7. Modifications to WebSockets</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-attr-fs-action">
+   <a href="https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fs-action">https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fs-action</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-attr-fs-action">8.1. Form Submission</a> <a href="#ref-for-attr-fs-action①">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-active-document">
+   <a href="https://html.spec.whatwg.org/multipage/browsers.html#active-document">https://html.spec.whatwg.org/multipage/browsers.html#active-document</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-active-document">5.2. Modifications to HTML</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-audio">
+   <a href="https://html.spec.whatwg.org/multipage/media.html#audio">https://html.spec.whatwg.org/multipage/media.html#audio</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-audio">3.1. Optionally-blockable Content</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-browsing-context">
+   <a href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context">https://html.spec.whatwg.org/multipage/browsers.html#browsing-context</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-browsing-context">2. Key Concepts and Terminology</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-bc-container-document">
+   <a href="https://html.spec.whatwg.org/multipage/browsers.html#bc-container-document">https://html.spec.whatwg.org/multipage/browsers.html#bc-container-document</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-bc-container-document">2. Key Concepts and Terminology</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-downloading-hyperlinks">
+   <a href="https://html.spec.whatwg.org/multipage/links.html#downloading-hyperlinks">https://html.spec.whatwg.org/multipage/links.html#downloading-hyperlinks</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-downloading-hyperlinks">5.2. Modifications to HTML</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-environment-settings-object">
+   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-environment-settings-object">4.3. 
+      Does settings prohibit mixed security contexts? </a> <a href="#ref-for-environment-settings-object①">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-the-form-element">
+   <a href="https://html.spec.whatwg.org/multipage/forms.html#the-form-element">https://html.spec.whatwg.org/multipage/forms.html#the-form-element</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-the-form-element">8.1. Form Submission</a> <a href="#ref-for-the-form-element①">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-global-object">
+   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object">https://html.spec.whatwg.org/multipage/webappapis.html#global-object</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-global-object">4.3. 
+      Does settings prohibit mixed security contexts? </a>
+    <li><a href="#ref-for-global-object①">7. Modifications to WebSockets</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-https-state">
+   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#https-state">https://html.spec.whatwg.org/multipage/webappapis.html#https-state</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-https-state">4.3. 
+      Does settings prohibit mixed security contexts? </a> <a href="#ref-for-https-state①">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-the-img-element">
+   <a href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element">https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-the-img-element">3.1. Optionally-blockable Content</a> <a href="#ref-for-the-img-element①">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-parent-browsing-context">
+   <a href="https://html.spec.whatwg.org/multipage/browsers.html#parent-browsing-context">https://html.spec.whatwg.org/multipage/browsers.html#parent-browsing-context</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-parent-browsing-context">4.4. 
+      Should fetching request be blocked as mixed content? </a>
+    <li><a href="#ref-for-parent-browsing-context①">4.5. 
+      Should response to request be blocked as mixed
+      content? </a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-plugin">
+   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#plugin">https://html.spec.whatwg.org/multipage/infrastructure.html#plugin</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-plugin">3.2. Blockable Content</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-process-a-navigate-response">
+   <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#process-a-navigate-response">https://html.spec.whatwg.org/multipage/browsing-the-web.html#process-a-navigate-response</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-process-a-navigate-response">5.2. Modifications to HTML</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-relevant-settings-object">
+   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-relevant-settings-object">4.3. 
+      Does settings prohibit mixed security contexts? </a>
+    <li><a href="#ref-for-relevant-settings-object①">7. Modifications to WebSockets</a>
+    <li><a href="#ref-for-relevant-settings-object②">8.1. Form Submission</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-responsible-document">
+   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-document">https://html.spec.whatwg.org/multipage/webappapis.html#responsible-document</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-responsible-document">4.3. 
+      Does settings prohibit mixed security contexts? </a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-the-source-element">
+   <a href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-source-element">https://html.spec.whatwg.org/multipage/embedded-content.html#the-source-element</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-the-source-element">3.1. Optionally-blockable Content</a> <a href="#ref-for-the-source-element①">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-concept-environment-target-browsing-context">
+   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-target-browsing-context">https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-target-browsing-context</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-concept-environment-target-browsing-context">4.4. 
+      Should fetching request be blocked as mixed content? </a>
+    <li><a href="#ref-for-concept-environment-target-browsing-context①">4.5. 
+      Should response to request be blocked as mixed
+      content? </a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-top-level-browsing-context">
+   <a href="https://html.spec.whatwg.org/multipage/browsers.html#top-level-browsing-context">https://html.spec.whatwg.org/multipage/browsers.html#top-level-browsing-context</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-top-level-browsing-context">3.2. Blockable Content</a>
+    <li><a href="#ref-for-top-level-browsing-context①">4.3. 
+      Does settings prohibit mixed security contexts? </a>
+    <li><a href="#ref-for-top-level-browsing-context②">8.1. Form Submission</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-use-srcset-or-picture">
+   <a href="https://html.spec.whatwg.org/multipage/images.html#use-srcset-or-picture">https://html.spec.whatwg.org/multipage/images.html#use-srcset-or-picture</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-use-srcset-or-picture">3.1. Optionally-blockable Content</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-video">
+   <a href="https://html.spec.whatwg.org/multipage/media.html#video">https://html.spec.whatwg.org/multipage/media.html#video</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-video">3.1. Optionally-blockable Content</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-section-7.1.7">
+   <a href="https://tools.ietf.org/html/rfc6455#section-7.1.7">https://tools.ietf.org/html/rfc6455#section-7.1.7</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-section-7.1.7">7. Modifications to WebSockets</a> <a href="#ref-for-section-7.1.7①">(2)</a> <a href="#ref-for-section-7.1.7②">(3)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-potentially-trustworthy-url">
+   <a href="https://w3c.github.io/webappsec-secure-contexts/#potentially-trustworthy-url">https://w3c.github.io/webappsec-secure-contexts/#potentially-trustworthy-url</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-potentially-trustworthy-url">2. Key Concepts and Terminology</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-url-scheme">
    <a href="https://url.spec.whatwg.org/#concept-url-scheme">https://url.spec.whatwg.org/#concept-url-scheme</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-url-scheme">3.1. Upgrade request to an a priori
-    authenticated URL as mixed content, if appropriate</a> <a href="#ref-for-concept-url-scheme①">(2)</a>
+    <li><a href="#ref-for-concept-url-scheme">2. Key Concepts and Terminology</a> <a href="#ref-for-concept-url-scheme①">(2)</a>
+    <li><a href="#ref-for-concept-url-scheme②">4.1. Upgrade request to an a priori
+    authenticated URL as mixed content, if appropriate</a> <a href="#ref-for-concept-url-scheme③">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-xmlhttprequest">
+   <a href="https://xhr.spec.whatwg.org/#xmlhttprequest">https://xhr.spec.whatwg.org/#xmlhttprequest</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-xmlhttprequest">3.2. Blockable Content</a>
+    <li><a href="#ref-for-xmlhttprequest①">7. Modifications to WebSockets</a>
    </ul>
   </aside>
   <h3 class="no-num no-ref heading settled" id="index-defined-elsewhere"><span class="content">Terms defined by reference</span><a class="self-link" href="#index-defined-elsewhere"></a></h3>
   <ul class="index">
    <li>
+    <a data-link-type="biblio">[css-backgrounds-3]</a> defines the following terms:
+    <ul>
+     <li><span class="dfn-paneled" id="term-for-propdef-background-image" style="color:initial">background-image</span>
+     <li><span class="dfn-paneled" id="term-for-propdef-border-image" style="color:initial">border-image</span>
+    </ul>
+   <li>
+    <a data-link-type="biblio">[DOM]</a> defines the following terms:
+    <ul>
+     <li><span class="dfn-paneled" id="term-for-document" style="color:initial">Document</span>
+     <li><span class="dfn-paneled" id="term-for-concept-node-document" style="color:initial">node document</span>
+     <li><span class="dfn-paneled" id="term-for-concept-document-url" style="color:initial">url</span>
+    </ul>
+   <li>
     <a data-link-type="biblio">[FETCH]</a> defines the following terms:
     <ul>
      <li><span class="dfn-paneled" id="term-for-concept-request-client" style="color:initial">client</span>
      <li><span class="dfn-paneled" id="term-for-concept-request-destination" style="color:initial">destination</span>
+     <li><span class="dfn-paneled" id="term-for-dom-global-fetch" style="color:initial">fetch(input)</span>
+     <li><span class="dfn-paneled" id="term-for-concept-response-https-state" style="color:initial">https state</span>
      <li><span class="dfn-paneled" id="term-for-concept-request-initiator" style="color:initial">initiator</span>
      <li><span class="dfn-paneled" id="term-for-concept-request-mode" style="color:initial">mode</span>
+     <li><span class="dfn-paneled" id="term-for-navigation-request" style="color:initial">navigation request</span>
      <li><span class="dfn-paneled" id="term-for-concept-request" style="color:initial">request</span>
-     <li><span class="dfn-paneled" id="term-for-concept-request-url" style="color:initial">url</span>
+     <li><span class="dfn-paneled" id="term-for-concept-response" style="color:initial">response</span>
+     <li><span class="dfn-paneled" id="term-for-concept-response-url" style="color:initial">url <small>(for response)</small></span>
+     <li><span class="dfn-paneled" id="term-for-concept-response-url-list" style="color:initial">url list</span>
+    </ul>
+   <li>
+    <a data-link-type="biblio">[HTML]</a> defines the following terms:
+    <ul>
+     <li><span class="dfn-paneled" id="term-for-eventsource" style="color:initial">EventSource</span>
+     <li><span class="dfn-paneled" id="term-for-websocket" style="color:initial">WebSocket</span>
+     <li><span class="dfn-paneled" id="term-for-attr-fs-action" style="color:initial">action</span>
+     <li><span class="dfn-paneled" id="term-for-active-document" style="color:initial">active document</span>
+     <li><span class="dfn-paneled" id="term-for-audio" style="color:initial">audio</span>
+     <li><span class="dfn-paneled" id="term-for-browsing-context" style="color:initial">browsing context</span>
+     <li><span class="dfn-paneled" id="term-for-bc-container-document" style="color:initial">container document</span>
+     <li><span class="dfn-paneled" id="term-for-downloading-hyperlinks" style="color:initial">downloads a hyperlink</span>
+     <li><span class="dfn-paneled" id="term-for-environment-settings-object" style="color:initial">environment settings object</span>
+     <li><span class="dfn-paneled" id="term-for-the-form-element" style="color:initial">form</span>
+     <li><span class="dfn-paneled" id="term-for-global-object" style="color:initial">global object</span>
+     <li><span class="dfn-paneled" id="term-for-https-state" style="color:initial">https state</span>
+     <li><span class="dfn-paneled" id="term-for-the-img-element" style="color:initial">img</span>
+     <li><span class="dfn-paneled" id="term-for-parent-browsing-context" style="color:initial">parent browsing context</span>
+     <li><span class="dfn-paneled" id="term-for-plugin" style="color:initial">plugin</span>
+     <li><span class="dfn-paneled" id="term-for-process-a-navigate-response" style="color:initial">process a navigate response</span>
+     <li><span class="dfn-paneled" id="term-for-relevant-settings-object" style="color:initial">relevant settings object</span>
+     <li><span class="dfn-paneled" id="term-for-responsible-document" style="color:initial">responsible document</span>
+     <li><span class="dfn-paneled" id="term-for-the-source-element" style="color:initial">source</span>
+     <li><span class="dfn-paneled" id="term-for-concept-environment-target-browsing-context" style="color:initial">target browsing context</span>
+     <li><span class="dfn-paneled" id="term-for-top-level-browsing-context" style="color:initial">top-level browsing context</span>
+     <li><span class="dfn-paneled" id="term-for-use-srcset-or-picture" style="color:initial">use srcset or picture</span>
+     <li><span class="dfn-paneled" id="term-for-video" style="color:initial">video</span>
+    </ul>
+   <li>
+    <a data-link-type="biblio">[RFC6455]</a> defines the following terms:
+    <ul>
+     <li><span class="dfn-paneled" id="term-for-section-7.1.7" style="color:initial">fail the websocket connection</span>
+    </ul>
+   <li>
+    <a data-link-type="biblio">[SECURE-CONTEXTS]</a> defines the following terms:
+    <ul>
+     <li><span class="dfn-paneled" id="term-for-potentially-trustworthy-url" style="color:initial">potentially trustworthy url</span>
     </ul>
    <li>
     <a data-link-type="biblio">[url]</a> defines the following terms:
     <ul>
      <li><span class="dfn-paneled" id="term-for-concept-url-scheme" style="color:initial">scheme</span>
     </ul>
+   <li>
+    <a data-link-type="biblio">[XHR]</a> defines the following terms:
+    <ul>
+     <li><span class="dfn-paneled" id="term-for-xmlhttprequest" style="color:initial">XMLHttpRequest</span>
+    </ul>
   </ul>
   <h2 class="no-num no-ref heading settled" id="references"><span class="content">References</span><a class="self-link" href="#references"></a></h2>
   <h3 class="no-num no-ref heading settled" id="normative"><span class="content">Normative References</span><a class="self-link" href="#normative"></a></h3>
   <dl>
+   <dt id="biblio-dom">[DOM]
+   <dd>Anne van Kesteren. <a href="https://dom.spec.whatwg.org/">DOM Standard</a>. Living Standard. URL: <a href="https://dom.spec.whatwg.org/">https://dom.spec.whatwg.org/</a>
    <dt id="biblio-fetch">[FETCH]
    <dd>Anne van Kesteren. <a href="https://fetch.spec.whatwg.org/">Fetch Standard</a>. Living Standard. URL: <a href="https://fetch.spec.whatwg.org/">https://fetch.spec.whatwg.org/</a>
+   <dt id="biblio-html">[HTML]
+   <dd>Anne van Kesteren; et al. <a href="https://html.spec.whatwg.org/multipage/">HTML Standard</a>. Living Standard. URL: <a href="https://html.spec.whatwg.org/multipage/">https://html.spec.whatwg.org/multipage/</a>
    <dt id="biblio-mixed-content">[MIXED-CONTENT]
    <dd>Mike West. <a href="https://www.w3.org/TR/mixed-content/">Mixed Content</a>. 2 August 2016. CR. URL: <a href="https://www.w3.org/TR/mixed-content/">https://www.w3.org/TR/mixed-content/</a>
    <dt id="biblio-rfc2119">[RFC2119]
    <dd>S. Bradner. <a href="https://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>. March 1997. Best Current Practice. URL: <a href="https://tools.ietf.org/html/rfc2119">https://tools.ietf.org/html/rfc2119</a>
+   <dt id="biblio-rfc6455">[RFC6455]
+   <dd>I. Fette; A. Melnikov. <a href="https://tools.ietf.org/html/rfc6455">The WebSocket Protocol</a>. December 2011. Proposed Standard. URL: <a href="https://tools.ietf.org/html/rfc6455">https://tools.ietf.org/html/rfc6455</a>
+   <dt id="biblio-rfc6797">[RFC6797]
+   <dd>J. Hodges; C. Jackson; A. Barth. <a href="https://tools.ietf.org/html/rfc6797">HTTP Strict Transport Security (HSTS)</a>. November 2012. Proposed Standard. URL: <a href="https://tools.ietf.org/html/rfc6797">https://tools.ietf.org/html/rfc6797</a>
+   <dt id="biblio-secure-contexts">[SECURE-CONTEXTS]
+   <dd>Mike West. <a href="https://www.w3.org/TR/secure-contexts/">Secure Contexts</a>. 15 September 2016. CR. URL: <a href="https://www.w3.org/TR/secure-contexts/">https://www.w3.org/TR/secure-contexts/</a>
    <dt id="biblio-url">[URL]
    <dd>Anne van Kesteren. <a href="https://url.spec.whatwg.org/">URL Standard</a>. Living Standard. URL: <a href="https://url.spec.whatwg.org/">https://url.spec.whatwg.org/</a>
+   <dt id="biblio-websockets">[WEBSOCKETS]
+   <dd>Ian Hickson. <a href="https://www.w3.org/TR/websockets/">The WebSocket API</a>. 20 September 2012. CR. URL: <a href="https://www.w3.org/TR/websockets/">https://www.w3.org/TR/websockets/</a>
+   <dt id="biblio-xhr">[XHR]
+   <dd>Anne van Kesteren. <a href="https://xhr.spec.whatwg.org/">XMLHttpRequest Standard</a>. Living Standard. URL: <a href="https://xhr.spec.whatwg.org/">https://xhr.spec.whatwg.org/</a>
   </dl>
   <h3 class="no-num no-ref heading settled" id="informative"><span class="content">Informative References</span><a class="self-link" href="#informative"></a></h3>
   <dl>
+   <dt id="biblio-css-backgrounds-3">[CSS-BACKGROUNDS-3]
+   <dd>Bert Bos; Elika Etemad; Brad Kemper. <a href="https://www.w3.org/TR/css-backgrounds-3/">CSS Backgrounds and Borders Module Level 3</a>. 17 October 2017. CR. URL: <a href="https://www.w3.org/TR/css-backgrounds-3/">https://www.w3.org/TR/css-backgrounds-3/</a>
+   <dt id="biblio-rfc6919">[RFC6919]
+   <dd>R. Barnes; S. Kent; E. Rescorla. <a href="https://tools.ietf.org/html/rfc6919">Further Key Words for Use in RFCs to Indicate Requirement Levels</a>. 1 April 2013. Experimental. URL: <a href="https://tools.ietf.org/html/rfc6919">https://tools.ietf.org/html/rfc6919</a>
    <dt id="biblio-upgrade-insecure-requests">[UPGRADE-INSECURE-REQUESTS]
    <dd>Mike West. <a href="https://www.w3.org/TR/upgrade-insecure-requests/">Upgrade Insecure Requests</a>. 8 October 2015. CR. URL: <a href="https://www.w3.org/TR/upgrade-insecure-requests/">https://www.w3.org/TR/upgrade-insecure-requests/</a>
+   <dt id="biblio-wsc-ui">[WSC-UI]
+   <dd>Thomas Roessler; Anil Saldhana. <a href="https://www.w3.org/TR/wsc-ui/">Web Security Context: User Interface Guidelines</a>. 12 August 2010. REC. URL: <a href="https://www.w3.org/TR/wsc-ui/">https://www.w3.org/TR/wsc-ui/</a>
+   <dt id="biblio-xml">[XML]
+   <dd>Tim Bray; et al. <a href="https://www.w3.org/TR/xml/">Extensible Markup Language (XML) 1.0 (Fifth Edition)</a>. 26 November 2008. REC. URL: <a href="https://www.w3.org/TR/xml/">https://www.w3.org/TR/xml/</a>
   </dl>
+  <aside class="dfn-panel" data-for="mixed-content">
+   <b><a href="#mixed-content">#mixed-content</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-mixed-content">3. Content Categories</a> <a href="#ref-for-mixed-content①">(2)</a>
+    <li><a href="#ref-for-mixed-content②">3.1. Optionally-blockable Content</a>
+    <li><a href="#ref-for-mixed-content③">4.4. 
+      Should fetching request be blocked as mixed content? </a>
+    <li><a href="#ref-for-mixed-content④">4.5. 
+      Should response to request be blocked as mixed
+      content? </a>
+    <li><a href="#ref-for-mixed-content⑤">8.2. User Controls</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="a-priori-authenticated-url">
+   <b><a href="#a-priori-authenticated-url">#a-priori-authenticated-url</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-a-priori-authenticated-url">2. Key Concepts and Terminology</a> <a href="#ref-for-a-priori-authenticated-url①">(2)</a>
+    <li><a href="#ref-for-a-priori-authenticated-url②">4.1. Upgrade request to an a priori
+    authenticated URL as mixed content, if appropriate</a>
+    <li><a href="#ref-for-a-priori-authenticated-url③">4.4. 
+      Should fetching request be blocked as mixed content? </a>
+    <li><a href="#ref-for-a-priori-authenticated-url④">5.2. Modifications to HTML</a> <a href="#ref-for-a-priori-authenticated-url⑤">(2)</a> <a href="#ref-for-a-priori-authenticated-url⑥">(3)</a> <a href="#ref-for-a-priori-authenticated-url⑦">(4)</a>
+    <li><a href="#ref-for-a-priori-authenticated-url⑧">8.1. Form Submission</a> <a href="#ref-for-a-priori-authenticated-url⑨">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="unauthenticated-response">
+   <b><a href="#unauthenticated-response">#unauthenticated-response</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-unauthenticated-response">2. Key Concepts and Terminology</a>
+    <li><a href="#ref-for-unauthenticated-response①">4.5. 
+      Should response to request be blocked as mixed
+      content? </a> <a href="#ref-for-unauthenticated-response②">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="embedding-document">
+   <b><a href="#embedding-document">#embedding-document</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-embedding-document">4.3. 
+      Does settings prohibit mixed security contexts? </a> <a href="#ref-for-embedding-document①">(2)</a> <a href="#ref-for-embedding-document②">(3)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="optionally-blockable-mixed-content">
+   <b><a href="#optionally-blockable-mixed-content">#optionally-blockable-mixed-content</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-optionally-blockable-mixed-content">2. Key Concepts and Terminology</a>
+    <li><a href="#ref-for-optionally-blockable-mixed-content①">3.2. Blockable Content</a>
+    <li><a href="#ref-for-optionally-blockable-mixed-content②">8.2. User Controls</a> <a href="#ref-for-optionally-blockable-mixed-content③">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="blockable-mixed-content">
+   <b><a href="#blockable-mixed-content">#blockable-mixed-content</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-blockable-mixed-content">2. Key Concepts and Terminology</a>
+    <li><a href="#ref-for-blockable-mixed-content①">4.4. 
+      Should fetching request be blocked as mixed content? </a>
+    <li><a href="#ref-for-blockable-mixed-content②">4.5. 
+      Should response to request be blocked as mixed
+      content? </a> <a href="#ref-for-blockable-mixed-content③">(2)</a>
+    <li><a href="#ref-for-blockable-mixed-content④">8.1. Form Submission</a>
+    <li><a href="#ref-for-blockable-mixed-content⑤">8.2. User Controls</a> <a href="#ref-for-blockable-mixed-content⑥">(2)</a>
+   </ul>
+  </aside>
 <script>/* script-dfn-panel */
 
 document.body.addEventListener("click", function(e) {

--- a/level2.fpwd.html
+++ b/level2.fpwd.html
@@ -7,7 +7,7 @@
   <link href="https://www.w3.org/StyleSheets/TR/2016/W3C-WD" rel="stylesheet" type="text/css">
   <meta content="Bikeshed version e1a165f1c2fb1cc2aceb87e110984a42830c36fa" name="generator">
   <link href="https://www.w3.org/TR/mixed-content-2/" rel="canonical">
-  <meta content="70f2ee524feedbfaa07d52894e3f6cdd0ec6dcb6" name="document-revision">
+  <meta content="08fce07e15a85e78b6ee96a116c02790aab035ef" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -196,11 +196,11 @@ pre .property::before, pre .property::after {
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1>Mixed Content Level 2</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">W3C First Public Working Draft, <time class="dt-updated" datetime="2020-03-20">20 March 2020</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">W3C First Public Working Draft, <time class="dt-updated" datetime="2020-03-25">25 March 2020</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
-     <dd><a class="u-url" href="https://www.w3.org/TR/2020/WD-mixed-content-2-2-20200320/">https://www.w3.org/TR/2020/WD-mixed-content-2-2-20200320/</a>
+     <dd><a class="u-url" href="https://www.w3.org/TR/2020/WD-mixed-content-2-2-20200325/">https://www.w3.org/TR/2020/WD-mixed-content-2-2-20200325/</a>
      <dt>Latest published version:
      <dd><a href="https://www.w3.org/TR/mixed-content-2/">https://www.w3.org/TR/mixed-content-2/</a>
      <dt>Editor's Draft:
@@ -266,7 +266,7 @@ pre .property::before, pre .property::after {
     <li>
      <a href="#categories"><span class="secno">3</span> <span class="content">Content Categories</span></a>
      <ol class="toc">
-      <li><a href="#category-optionally-blockable"><span class="secno">3.1</span> <span class="content">Optionally-blockable Content</span></a>
+      <li><a href="#category-upgradeable"><span class="secno">3.1</span> <span class="content">Upgradeable Content</span></a>
       <li><a href="#category-blockable"><span class="secno">3.2</span> <span class="content">Blockable Content</span></a>
      </ol>
     <li>
@@ -291,14 +291,13 @@ pre .property::before, pre .property::after {
       <li><a href="#block-all-mixed-content"><span class="secno">6.1</span> <span class="content"><code>block-all-mixed-content</code></span></a>
       <li><a href="#mixed-content-1"><span class="secno">6.2</span> <span class="content"><code>Mixed Content</code></span></a>
      </ol>
-    <li><a href="#websockets-integration"><span class="secno">7</span> <span class="content">Modifications to WebSockets</span></a>
     <li>
-     <a href="#security-considerations"><span class="secno">8</span> <span class="content">Security and Privacy Considerations</span></a>
+     <a href="#security-considerations"><span class="secno">7</span> <span class="content">Security and Privacy Considerations</span></a>
      <ol class="toc">
-      <li><a href="#requirements-forms"><span class="secno">8.1</span> <span class="content">Form Submission</span></a>
-      <li><a href="#requirements-user-controls"><span class="secno">8.2</span> <span class="content">User Controls</span></a>
+      <li><a href="#requirements-forms"><span class="secno">7.1</span> <span class="content">Form Submission</span></a>
+      <li><a href="#requirements-user-controls"><span class="secno">7.2</span> <span class="content">User Controls</span></a>
      </ol>
-    <li><a href="#acknowledgements"><span class="secno">9</span> <span class="content">Acknowledgements</span></a>
+    <li><a href="#acknowledgements"><span class="secno">8</span> <span class="content">Acknowledgements</span></a>
     <li>
      <a href="#conformance"><span class="secno"></span> <span class="content">Conformance</span></a>
      <ol class="toc">
@@ -377,22 +376,18 @@ pre .property::before, pre .property::after {
       loading it requires prohibits mixed security contexts (see <a href="#categorize-settings-object">§ 4.3 Does settings prohibit mixed security contexts?</a> for a normative definition of the latter). 
       <p>A <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response">response</a> is <strong>mixed content</strong> if it is an <a data-link-type="dfn" href="#unauthenticated-response" id="ref-for-unauthenticated-response">unauthenticated response</a>, <strong>and</strong> the context
       responsible for loading it requires prohibits mixed security contexts.</p>
-      <div class="example" id="example-13a780ee">
-       <a class="self-link" href="#example-13a780ee"></a> Inside a context that restricts mixed content
+      <div class="example" id="example-14c50224">
+       <a class="self-link" href="#example-14c50224"></a> Inside a context that restricts mixed content
         (<code>https://secure.example.com/</code>, for example): 
        <ol>
         <li data-md>
          <p>A request for the script <code>http://example.com/script.js</code> is <strong>mixed content</strong>. As script <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request①">requests</a> are <a data-link-type="dfn" href="#blockable-mixed-content" id="ref-for-blockable-mixed-content">blockable</a>, the user agent will return a network error rather
   than loading the resource.</p>
         <li data-md>
-         <p>A request for the image <code>http://example.com/image.png</code> is <strong>mixed content</strong>. As image <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②">requests</a> are <a data-link-type="dfn" href="#optionally-blockable-mixed-content" id="ref-for-optionally-blockable-mixed-content">optionally-blockable</a>, the user agent might load the image, in
-  which case the image resource itself would be <strong>mixed
-  content</strong>.</p>
+         <p>A request for the image <code>http://example.com/image.png</code> is <strong>mixed content</strong>. As image <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②">requests</a> are <a data-link-type="dfn" href="#upgradeable-mixed-content" id="ref-for-upgradeable-mixed-content">upgradeable</a>, the user agent might rewrite the URL as <code>http://example.com/image.png</code>, otherwise it will block
+  the load.</p>
        </ol>
       </div>
-      <p>If mixed content is loaded into a context that restricts mixed content
-      (as in #2 above), that context is considered a <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6797#section-12.4" id="ref-for-section-12.4">mixed security
-      context</a> (as defined in <a data-link-type="biblio" href="#biblio-rfc6797">[RFC6797]</a>).</p>
       <p class="note" role="note"><span>Note:</span> "Mixed content" was originally defined in <a href="https://www.w3.org/TR/wsc-ui/#securepage">section 5.3</a> of <a data-link-type="biblio" href="#biblio-wsc-ui">[WSC-UI]</a>. This document updates that initial definition.</p>
       <p class="note" role="note"><span>Note:</span> <a data-link-type="biblio" href="#biblio-xml">[XML]</a> also defines an unrelated <a href="https://www.w3.org/TR/2008/REC-xml-20081126/#sec-mixed-content">"mixed content"</a>.
       concept. This is potentially confusing, but given the term’s near
@@ -440,16 +435,14 @@ pre .property::before, pre .property::after {
   content</a> without exception. Unfortunately, that is impractical on today’s
   Internet; a user agent needs to be more nuanced in its restrictions to avoid
   degrading the experience on a substantial number of websites.</p>
-    <p>With that in mind, we here split mixed content into two categories: <a href="#category-optionally-blockable">§ 3.1 Optionally-blockable Content</a> and <a href="#category-blockable">§ 3.2 Blockable Content</a>.</p>
-    <p class="note" role="note"><span>Note:</span> Future versions of this specification will update this categorization
-  with the intent of moving towards a world where all <a data-link-type="dfn" href="#mixed-content" id="ref-for-mixed-content①">mixed</a> content is
-  blocked; that is the end goal, but this is the best we can do for now.</p>
+    <p>With that in mind, we here split mixed content into two categories: <a href="#category-upgradeable">§ 3.1 Upgradeable Content</a> and <a href="#category-blockable">§ 3.2 Blockable Content</a>.</p>
     <section>
-     <h3 class="heading settled" data-level="3.1" id="category-optionally-blockable"><span class="secno">3.1. </span><span class="content">Optionally-blockable Content</span><a class="self-link" href="#category-optionally-blockable"></a></h3>
-     <p>Mixed content is <dfn class="dfn-paneled" data-dfn-type="dfn" data-export data-local-lt="optionally-blockable" data-lt="optionally-blockable mixed content" id="optionally-blockable-mixed-content">optionally-blockable</dfn> when the risk of allowing its usage as <a data-link-type="dfn" href="#mixed-content" id="ref-for-mixed-content②">mixed content</a> is outweighed by the risk of
+     <h3 class="heading settled" data-level="3.1" id="category-upgradeable"><span class="secno">3.1. </span><span class="content">Upgradeable Content</span><a class="self-link" href="#category-upgradeable"></a></h3>
+     <note>Upgradeable content was previously referred as optionally-blockable in <a data-link-type="biblio" href="#biblio-mixed-content">[mixed-content]</a></note>
+     <p>Mixed content is <dfn class="dfn-paneled" data-dfn-type="dfn" data-export data-local-lt="upgradeable" data-lt="upgradeable mixed content" id="upgradeable-mixed-content">upgradeable</dfn> when the risk of allowing its usage as <a data-link-type="dfn" href="#mixed-content" id="ref-for-mixed-content①">mixed content</a> is outweighed by the risk of
     breaking significant portions of the web. This could be because mixed usage of the resource type
     is sufficiently high, and because the resource is low-risk in and of itself. The fact that these
-    resource types are optionally-blockable does not mean that they are <em>safe</em>, simply that
+    resource types are upgradeable does not mean that they are <em>safe</em>, simply that
     they’re less catastrophically dangerous than other resource types. For example, images and icons
     are often the central UI elements in an application’s interface. If an attacker reversed the
     "Delete email" and "Reply" icons, there would be real impact to users.</p>
@@ -475,7 +468,7 @@ pre .property::before, pre .property::after {
     </section>
     <section>
      <h3 class="heading settled" data-level="3.2" id="category-blockable"><span class="secno">3.2. </span><span class="content">Blockable Content</span><a class="self-link" href="#category-blockable"></a></h3>
-     <p>Any mixed content that is not <a data-link-type="dfn" href="#optionally-blockable-mixed-content" id="ref-for-optionally-blockable-mixed-content①">optionally-blockable</a> as defined above is considered to be <dfn class="dfn-paneled" data-dfn-type="dfn" data-export data-local-lt="blockable" data-lt="blockable mixed content" id="blockable-mixed-content">blockable</dfn>. Typical examples
+     <p>Any mixed content that is not <a data-link-type="dfn" href="#upgradeable-mixed-content" id="ref-for-upgradeable-mixed-content①">upgradeable</a> as defined above is considered to be <dfn class="dfn-paneled" data-dfn-type="dfn" data-export data-local-lt="blockable" data-lt="blockable mixed content" id="blockable-mixed-content">blockable</dfn>. Typical examples
     of this kind of content include scripts, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#plugin" id="ref-for-plugin">plugin</a> data, data requested via <code class="idl"><a data-link-type="idl" href="https://xhr.spec.whatwg.org/#xmlhttprequest" id="ref-for-xmlhttprequest">XMLHttpRequest</a></code>, and so on.</p>
      <p class="note" role="note"><span>Note:</span> <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#navigation-request" id="ref-for-navigation-request">Navigation requests</a> might target <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#top-level-browsing-context" id="ref-for-top-level-browsing-context">top-level browsing contexts</a>; these are not
     considered mixed content. See <a href="#should-block-fetch">§ 4.4 Should fetching request be blocked as mixed content?</a> for details.</p>
@@ -483,23 +476,23 @@ pre .property::before, pre .property::after {
     user agents aren’t always in a position to mediate these requests. NPAPI plugins, for instance,
     often have direct network access, and can generally bypass the user agent entirely. We recommend
     that user agents block these requests when possible, and that plugin vendors implement mixed
-    content checking themselves to mitigate the risks o utlined in this document.</p>
+    content checking themselves to mitigate the risks outlined in this document.</p>
     </section>
    </section>
    <section>
     <h2 class="heading settled" data-level="4" id="algorithms"><span class="secno">4. </span><span class="content">Algorithms</span><a class="self-link" href="#algorithms"></a></h2>
     <section>
      <h3 class="heading settled" data-level="4.1" id="upgrade-algorithm"><span class="secno">4.1. </span><span class="content">Upgrade <var>request</var> to an <i lang="la">a priori</i> authenticated URL as mixed content, if appropriate</span><a class="self-link" href="#upgrade-algorithm"></a></h3>
-     <p class="note" role="note"><span>Note:</span> The Fetch specification will hook into this algorithm to upgrade optionally-blockable
+     <p class="note" role="note"><span>Note:</span> The Fetch specification will hook into this algorithm to upgrade upgradeable
     mixed content to HTTPS.</p>
      <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③">Request</a> <var>request</var>, this algorithm will rewrite
-    its <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url①">url</a> if the request is deemed to be optionally-blockable mixed content,
+    its <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url①">url</a> if the request is deemed to be upgradeable mixed content,
     via the following algorithm:</p>
      <ol>
       <li>
         If one or more of the following conditions is met, return without modifying <var>request</var>: 
        <ol>
-        <li> <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url②">url</a> is an <a data-link-type="dfn" href="#a-priori-authenticated-url" id="ref-for-a-priori-authenticated-url②"><i lang="la">a priori</i> authenticated URLs</a> 
+        <li> <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url②">url</a> is an <a data-link-type="dfn" href="#a-priori-authenticated-url" id="ref-for-a-priori-authenticated-url②"><i lang="la">a priori</i> authenticated URL</a> 
         <li> <a href="#categorize-settings-object">§ 4.3 Does settings prohibit mixed security contexts?</a> returns "<code>Does Not Restrict Mixed Security
             Contents</code>" when applied to <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client">client</a>. 
         <li> <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-mode" id="ref-for-concept-request-mode">mode</a> is <code>CORS</code>. 
@@ -588,15 +581,15 @@ pre .property::before, pre .property::after {
        <ol>
         <li> <a href="#categorize-settings-object">§ 4.3 Does settings prohibit mixed security contexts?</a> returns "<code>Does Not Restrict Mixed Security Contexts</code>" when applied to <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client①">client</a>. 
         <li> <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url⑤">url</a> is <a data-link-type="dfn" href="#a-priori-authenticated-url" id="ref-for-a-priori-authenticated-url③"><i lang="la">a priori</i> authenticated</a>. 
-        <li> The user agent has been instructed to allow <a data-link-type="dfn" href="#mixed-content" id="ref-for-mixed-content③">mixed content</a>, as
-            described in <a href="#requirements-user-controls">§ 8.2 User Controls</a>). 
+        <li> The user agent has been instructed to allow <a data-link-type="dfn" href="#mixed-content" id="ref-for-mixed-content②">mixed content</a>, as
+            described in <a href="#requirements-user-controls">§ 7.2 User Controls</a>). 
         <li>
           <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination⑤">destination</a> is
             "<code>document</code>", and <var>request</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-target-browsing-context" id="ref-for-concept-environment-target-browsing-context">target browsing
             context</a> has no <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#parent-browsing-context" id="ref-for-parent-browsing-context">parent browsing context</a>. 
          <p class="note" role="note"><span>Note:</span> We exclude top-level navigations from mixed content checks,
             but user agents MAY choose to enforce mixed content checks on
-            insecure form submissions (see <a href="#requirements-forms">§ 8.1 Form Submission</a>).</p>
+            insecure form submissions (see <a href="#requirements-forms">§ 7.1 Form Submission</a>).</p>
        </ol>
       <li> Return <strong>blocked</strong>. 
      </ol>
@@ -621,15 +614,15 @@ pre .property::before, pre .property::after {
         <li> <a href="#categorize-settings-object">§ 4.3 Does settings prohibit mixed security contexts?</a> returns <code>Does Not Restrict
             Mixed Content</code> when applied to <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client②">client</a>. 
         <li> <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-https-state" id="ref-for-concept-response-https-state①">HTTPS state</a> is <code>modern</code>. 
-        <li> The user agent has been instructed to allow <a data-link-type="dfn" href="#mixed-content" id="ref-for-mixed-content④">mixed content</a>, as
-            described in <a href="#requirements-user-controls">§ 8.2 User Controls</a>). 
+        <li> The user agent has been instructed to allow <a data-link-type="dfn" href="#mixed-content" id="ref-for-mixed-content③">mixed content</a>, as
+            described in <a href="#requirements-user-controls">§ 7.2 User Controls</a>). 
         <li>
           <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination⑥">destination</a> is
             "<code>document</code>", and <var>request</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-target-browsing-context" id="ref-for-concept-environment-target-browsing-context①">target browsing
             context</a> has no <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#parent-browsing-context" id="ref-for-parent-browsing-context①">parent browsing context</a>. 
          <p class="note" role="note"><span>Note:</span> We exclude top-level navigations from mixed content checks,
             but user agents MAY choose to enforce mixed content checks on
-            insecure form submissions (see <a href="#requirements-forms">§ 8.1 Form Submission</a>).</p>
+            insecure form submissions (see <a href="#requirements-forms">§ 7.1 Form Submission</a>).</p>
        </ol>
       <li>Return <strong>blocked</strong>.
      </ol>
@@ -639,7 +632,7 @@ pre .property::before, pre .property::after {
     <h2 class="heading settled" data-level="5" id="integration"><span class="secno">5. </span><span class="content">Integrations</span><a class="self-link" href="#integration"></a></h2>
     <h3 class="heading settled" data-level="5.1" id="fetch"><span class="secno">5.1. </span><span class="content">Modifications to Fetch</span><a class="self-link" href="#fetch"></a></h3>
     <p><a href="https://fetch.spec.whatwg.org/#main-fetch">Fetch Standard §4.1 Main fetch</a> should be modified to call <a href="#upgrade-algorithm">§ 4.1 Upgrade request to an a priori
-    authenticated URL as mixed content, if appropriate</a> on <var>request</var> between steps 3 and 4. That is, optionally-blockable mixed content should be autoupgraded to HTTPS
+    authenticated URL as mixed content, if appropriate</a> on <var>request</var> between steps 3 and 4. That is, upgradeable mixed content should be autoupgraded to HTTPS
   before applying mixed content blocking.</p>
     <h3 class="heading settled" data-level="5.2" id="html"><span class="secno">5.2. </span><span class="content">Modifications to HTML</span><a class="self-link" href="#html"></a></h3>
     <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#process-a-navigate-response" id="ref-for-process-a-navigate-response">Process a navigate response</a> should be modified as follows. Step 3 should abort the download
@@ -665,45 +658,14 @@ pre .property::before, pre .property::after {
   because all mixed content is now blocked if it can’t be autoupgraded.</p>
     <p class="note" role="note"><span>Note:</span> The <code>upgrade-insecure-requests</code> (<a data-link-type="biblio" href="#biblio-upgrade-insecure-requests">[upgrade-insecure-requests]</a>) directive is not
   obsolete because it allows developers to upgrade blockable content. This specification only
-  upgrades optionally-blockable content by default.</p>
+  upgrades upgradeable content by default.</p>
     <h3 class="heading settled" data-level="6.2" id="mixed-content-1"><span class="secno">6.2. </span><span class="content"><code>Mixed Content</code></span><a class="self-link" href="#mixed-content-1"></a></h3>
     <p>This specification renders the <a data-link-type="biblio" href="#biblio-mixed-content">[mixed-content]</a> specification obsolete,
   and replaces it.</p>
    </section>
    <section>
-    <h2 class="heading settled" data-level="7" id="websockets-integration"><span class="secno">7. </span><span class="content">Modifications to WebSockets</span><a class="self-link" href="#websockets-integration"></a></h2>
-    <p>The <a href="https://www.w3.org/TR/websockets/#the-websocket-interface"><code>WebSocket()</code> constructor algorithm</a> <a data-link-type="biblio" href="#biblio-websockets">[WEBSOCKETS]</a> is modified as follows:</p>
-    <ul>
-     <li> Remove the current step 2. 
-    </ul>
-    <p class="note" role="note"><span>Note:</span> This suggestion is filed as <a href="https://www.w3.org/Bugs/Public/show_bug.cgi?id=28841">bug #28841</a> against <a data-link-type="biblio" href="#biblio-websockets">[WEBSOCKETS]</a>.</p>
-    <p>The <a href="http://tools.ietf.org/html/rfc6455#section-4.1">Establish a
-  WebSocket Connection algorithm</a> <a data-link-type="biblio" href="#biblio-rfc6455">[RFC6455]</a> is modified as follows:</p>
-    <ol>
-     <li data-md>
-      <p>After the current step 1, perform the following step:</p>
-      <ol>
-       <li data-md>
-        <p>If <var>secure</var> is <code>false</code>, and the algorithm in <a href="#categorize-settings-object">§ 4.3 Does settings prohibit mixed security contexts?</a> returns "<code>Restricts Mixed Security Context</code>" when applied to <var>client</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object①">global object</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object" id="ref-for-relevant-settings-object①">relevant settings object</a>, then the client MUST <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6455#section-7.1.7" id="ref-for-section-7.1.7">fail the
-  WebSocket connection</a> and abort the connection <a data-link-type="biblio" href="#biblio-rfc6455">[RFC6455]</a>.</p>
-      </ol>
-     <li data-md>
-      <p>After the current step 5, perform the following step:</p>
-      <ol start="6">
-       <li data-md>
-        <p>If <var>secure</var> is <code>true</code>, and the TLS handshake performed in step 5
-  results in an HTTPS state of "<code>deprecated</code>", then the client MUST <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6455#section-7.1.7" id="ref-for-section-7.1.7①">fail the WebSocket connection</a> and abort the connection <a data-link-type="biblio" href="#biblio-rfc6455">[RFC6455]</a>.</p>
-      </ol>
-    </ol>
-    <p class="note" role="note"><span>Note:</span> Filed as <a href="http://www.rfc-editor.org/errata_search.php?rfc=6455&amp;eid=4398">errata #4398</a> against <a data-link-type="biblio" href="#biblio-rfc6455">[RFC6455]</a>.</p>
-    <p>These changes together mean that we’ll no longer throw a <code>SecurityError</code> exception directly upon constructing a WebSocket object, but will instead rely
-  upon blocking the connection and triggering the <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6455#section-7.1.7" id="ref-for-section-7.1.7②">fail the WebSocket
-  connection</a> algorithm, which developers can catch by hooking a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/web-sockets.html#websocket" id="ref-for-websocket">WebSocket</a></code> object’s <code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/websockets/#handler-websocket-onerror" id="ref-for-handler-websocket-onerror">onerror</a></code> handler. This is consistent with
-  the behavior of <code class="idl"><a data-link-type="idl" href="https://xhr.spec.whatwg.org/#xmlhttprequest" id="ref-for-xmlhttprequest①">XMLHttpRequest</a></code>, <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/server-sent-events.html#eventsource" id="ref-for-eventsource">EventSource</a></code>, and <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#dom-global-fetch" id="ref-for-dom-global-fetch">fetch()</a></code>.</p>
-   </section>
-   <section>
-    <h2 class="heading settled" data-level="8" id="security-considerations"><span class="secno">8. </span><span class="content">Security and Privacy Considerations</span><a class="self-link" href="#security-considerations"></a></h2>
-    <p>Overall, autoupgrading optionally-blockable mixed content is expected to be security- and
+    <h2 class="heading settled" data-level="7" id="security-considerations"><span class="secno">7. </span><span class="content">Security and Privacy Considerations</span><a class="self-link" href="#security-considerations"></a></h2>
+    <p>Overall, autoupgrading upgradeable mixed content is expected to be security- and
   privacy-positive, by protecting more user traffic from network eavesdropping and tampering.</p>
     <p>There is a risk of introducing a security or privacy issue in a webpage by loading a resource that
   the developer did not intend. For example, suppose that a website includes an innocuous image
@@ -711,12 +673,12 @@ pre .property::before, pre .property::after {
   reason <code>https://www.example.com/image.jpg</code> redirects to a tracking site. The browser
   will now have introduced a privacy issue without the developer’s or user’s explicit
   consent. However, these cases are expected to be exceedingly rare. The risk is mitigated by
-  autoupgrading only optionally-blockable content, not blockable content as well. Blockable content
+  autoupgrading only upgradeable content, not blockable content as well. Blockable content
   could present more risk, for example the risk of loading an out-of-date and vulnerable JavaScript
   library.</p>
     <section>
-     <h3 class="heading settled" data-level="8.1" id="requirements-forms"><span class="secno">8.1. </span><span class="content">Form Submission</span><a class="self-link" href="#requirements-forms"></a></h3>
-     <p>If <a href="#categorize-settings-object">§ 4.3 Does settings prohibit mixed security contexts?</a> returns <code>Restricts Mixed Content</code> when applied to a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①">Document</a></code>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object" id="ref-for-relevant-settings-object②">relevant settings object</a>, then a user agent MAY choose to warn users of the
+     <h3 class="heading settled" data-level="7.1" id="requirements-forms"><span class="secno">7.1. </span><span class="content">Form Submission</span><a class="self-link" href="#requirements-forms"></a></h3>
+     <p>If <a href="#categorize-settings-object">§ 4.3 Does settings prohibit mixed security contexts?</a> returns <code>Restricts Mixed Content</code> when applied to a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①">Document</a></code>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object" id="ref-for-relevant-settings-object①">relevant settings object</a>, then a user agent MAY choose to warn users of the
     presence of one or more <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/forms.html#the-form-element" id="ref-for-the-form-element">form</a></code> elements with <a data-link-type="element-attr" href="https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fs-action" id="ref-for-attr-fs-action">action</a> attributes whose
     values are not <a data-link-type="dfn" href="#a-priori-authenticated-url" id="ref-for-a-priori-authenticated-url⑧"><i lang="la">a priori</i> authenticated URLs</a></p>
      <p>A user agent MAY choose to warn users on submission of a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/forms.html#the-form-element" id="ref-for-the-form-element①">form</a></code> element with <a data-link-type="element-attr" href="https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fs-action" id="ref-for-attr-fs-action①">action</a> attributes whose values are not <a data-link-type="dfn" href="#a-priori-authenticated-url" id="ref-for-a-priori-authenticated-url⑨"><i lang="la">a priori</i> authenticated URLs</a> and allow users to abort the submission.</p>
@@ -724,25 +686,20 @@ pre .property::before, pre .property::after {
     </section>
    </section>
    <section>
-    <h3 class="heading settled" data-level="8.2" id="requirements-user-controls"><span class="secno">8.2. </span><span class="content">User Controls</span><a class="self-link" href="#requirements-user-controls"></a></h3>
-    <p>A user agent MAY offer users the ability to directly decide whether or not
-    to treat <strong>all</strong> <a data-link-type="dfn" href="#mixed-content" id="ref-for-mixed-content⑤">mixed content</a> as <a data-link-type="dfn" href="#blockable-mixed-content" id="ref-for-blockable-mixed-content⑤">blockable</a> (meaning that even <a data-link-type="dfn" href="#optionally-blockable-mixed-content" id="ref-for-optionally-blockable-mixed-content②">optionally-blockable</a> mixed content would be
-    blocked).</p>
-    <p class="note" role="note"><span>Note:</span> It is <em>strongly recommended</em> that users take advantage of such
-    an option if provided.</p>
-    <p>A user agent MAY offer users the ability to override its decision to block <a data-link-type="dfn" href="#blockable-mixed-content" id="ref-for-blockable-mixed-content⑥">blockable</a> mixed content on a particular page.</p>
+    <h3 class="heading settled" data-level="7.2" id="requirements-user-controls"><span class="secno">7.2. </span><span class="content">User Controls</span><a class="self-link" href="#requirements-user-controls"></a></h3>
+     A user agent MAY offer users the ability to override its decision to block <a data-link-type="dfn" href="#blockable-mixed-content" id="ref-for-blockable-mixed-content⑤">blockable</a> mixed content on a particular page. 
     <p class="note" role="note"><span>Note:</span> Practically, a user agent probably can’t get away with not offering
     such a back door. That said, allowing mixed script is in particular a very
     dangerous option, and each user agent <a href="http://tools.ietf.org/html/rfc6919#section-3">REALLY SHOULD NOT</a> <a data-link-type="biblio" href="#biblio-rfc6919">[RFC6919]</a> present such a choice to users without careful consideration and
     communication of the risk involved.</p>
     <p>A user agent MAY offer users the ability to override its decision to
-    automatically upgrade <a data-link-type="dfn" href="#optionally-blockable-mixed-content" id="ref-for-optionally-blockable-mixed-content③">optionally-blockable</a> mixed content on a
+    automatically upgrade <a data-link-type="dfn" href="#upgradeable-mixed-content" id="ref-for-upgradeable-mixed-content②">upgradeable</a> mixed content on a
     particular page.</p>
     <p>Any such controls offered by a user agent MUST also be offered through
     accessibility APIs for users of assistive technologies.</p>
    </section>
    <section>
-    <h2 class="heading settled" data-level="9" id="acknowledgements"><span class="secno">9. </span><span class="content">Acknowledgements</span><a class="self-link" href="#acknowledgements"></a></h2>
+    <h2 class="heading settled" data-level="8" id="acknowledgements"><span class="secno">8. </span><span class="content">Acknowledgements</span><a class="self-link" href="#acknowledgements"></a></h2>
    </section>
   </main>
   <h2 class="no-ref no-num heading settled" id="conformance"><span class="content">Conformance</span><a class="self-link" href="#conformance"></a></h2>
@@ -788,28 +745,28 @@ pre .property::before, pre .property::after {
    <li><a href="#mixed-content">mixed</a><span>, in §2</span>
    <li><a href="#mixed-content">mixed content</a><span>, in §2</span>
    <li><a href="#mixed-download">mixed download</a><span>, in §2</span>
-   <li><a href="#optionally-blockable-mixed-content">optionally-blockable</a><span>, in §3.1</span>
-   <li><a href="#optionally-blockable-mixed-content">optionally-blockable mixed content</a><span>, in §3.1</span>
    <li><a href="#unauthenticated-response">unauthenticated</a><span>, in §2</span>
    <li><a href="#unauthenticated-response">unauthenticated response</a><span>, in §2</span>
+   <li><a href="#upgradeable-mixed-content">upgradeable</a><span>, in §3.1</span>
+   <li><a href="#upgradeable-mixed-content">upgradeable mixed content</a><span>, in §3.1</span>
   </ul>
   <aside class="dfn-panel" data-for="term-for-propdef-background-image">
    <a href="https://www.w3.org/TR/css3-background/#propdef-background-image">https://www.w3.org/TR/css3-background/#propdef-background-image</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-propdef-background-image">3.1. Optionally-blockable Content</a>
+    <li><a href="#ref-for-propdef-background-image">3.1. Upgradeable Content</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-propdef-border-image">
    <a href="https://www.w3.org/TR/css3-background/#propdef-border-image">https://www.w3.org/TR/css3-background/#propdef-border-image</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-propdef-border-image">3.1. Optionally-blockable Content</a>
+    <li><a href="#ref-for-propdef-border-image">3.1. Upgradeable Content</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-document">
    <a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-document">2. Key Concepts and Terminology</a>
-    <li><a href="#ref-for-document①">8.1. Form Submission</a> <a href="#ref-for-document②">(2)</a>
+    <li><a href="#ref-for-document①">7.1. Form Submission</a> <a href="#ref-for-document②">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-node-document">
@@ -839,7 +796,7 @@ pre .property::before, pre .property::after {
   <aside class="dfn-panel" data-for="term-for-concept-request-destination">
    <a href="https://fetch.spec.whatwg.org/#concept-request-destination">https://fetch.spec.whatwg.org/#concept-request-destination</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-request-destination">3.1. Optionally-blockable Content</a> <a href="#ref-for-concept-request-destination①">(2)</a> <a href="#ref-for-concept-request-destination②">(3)</a>
+    <li><a href="#ref-for-concept-request-destination">3.1. Upgradeable Content</a> <a href="#ref-for-concept-request-destination①">(2)</a> <a href="#ref-for-concept-request-destination②">(3)</a>
     <li><a href="#ref-for-concept-request-destination③">4.1. Upgrade request to an a priori
     authenticated URL as mixed content, if appropriate</a> <a href="#ref-for-concept-request-destination④">(2)</a>
     <li><a href="#ref-for-concept-request-destination⑤">4.4. 
@@ -847,12 +804,6 @@ pre .property::before, pre .property::after {
     <li><a href="#ref-for-concept-request-destination⑥">4.5. 
       Should response to request be blocked as mixed
       content? </a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-global-fetch">
-   <a href="https://fetch.spec.whatwg.org/#dom-global-fetch">https://fetch.spec.whatwg.org/#dom-global-fetch</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-dom-global-fetch">7. Modifications to WebSockets</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-response-https-state">
@@ -867,7 +818,7 @@ pre .property::before, pre .property::after {
   <aside class="dfn-panel" data-for="term-for-concept-request-initiator">
    <a href="https://fetch.spec.whatwg.org/#concept-request-initiator">https://fetch.spec.whatwg.org/#concept-request-initiator</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-request-initiator">3.1. Optionally-blockable Content</a>
+    <li><a href="#ref-for-concept-request-initiator">3.1. Upgradeable Content</a>
     <li><a href="#ref-for-concept-request-initiator①">4.1. Upgrade request to an a priori
     authenticated URL as mixed content, if appropriate</a>
    </ul>
@@ -919,22 +870,10 @@ pre .property::before, pre .property::after {
     <li><a href="#ref-for-concept-response-url-list">5.2. Modifications to HTML</a> <a href="#ref-for-concept-response-url-list①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-eventsource">
-   <a href="https://html.spec.whatwg.org/multipage/server-sent-events.html#eventsource">https://html.spec.whatwg.org/multipage/server-sent-events.html#eventsource</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-eventsource">7. Modifications to WebSockets</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-websocket">
-   <a href="https://html.spec.whatwg.org/multipage/web-sockets.html#websocket">https://html.spec.whatwg.org/multipage/web-sockets.html#websocket</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-websocket">7. Modifications to WebSockets</a>
-   </ul>
-  </aside>
   <aside class="dfn-panel" data-for="term-for-attr-fs-action">
    <a href="https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fs-action">https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fs-action</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-attr-fs-action">8.1. Form Submission</a> <a href="#ref-for-attr-fs-action①">(2)</a>
+    <li><a href="#ref-for-attr-fs-action">7.1. Form Submission</a> <a href="#ref-for-attr-fs-action①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-active-document">
@@ -946,7 +885,7 @@ pre .property::before, pre .property::after {
   <aside class="dfn-panel" data-for="term-for-audio">
    <a href="https://html.spec.whatwg.org/multipage/media.html#audio">https://html.spec.whatwg.org/multipage/media.html#audio</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-audio">3.1. Optionally-blockable Content</a>
+    <li><a href="#ref-for-audio">3.1. Upgradeable Content</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-browsing-context">
@@ -977,7 +916,7 @@ pre .property::before, pre .property::after {
   <aside class="dfn-panel" data-for="term-for-the-form-element">
    <a href="https://html.spec.whatwg.org/multipage/forms.html#the-form-element">https://html.spec.whatwg.org/multipage/forms.html#the-form-element</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-the-form-element">8.1. Form Submission</a> <a href="#ref-for-the-form-element①">(2)</a>
+    <li><a href="#ref-for-the-form-element">7.1. Form Submission</a> <a href="#ref-for-the-form-element①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-global-object">
@@ -985,7 +924,6 @@ pre .property::before, pre .property::after {
    <ul>
     <li><a href="#ref-for-global-object">4.3. 
       Does settings prohibit mixed security contexts? </a>
-    <li><a href="#ref-for-global-object①">7. Modifications to WebSockets</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-https-state">
@@ -998,7 +936,7 @@ pre .property::before, pre .property::after {
   <aside class="dfn-panel" data-for="term-for-the-img-element">
    <a href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element">https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-the-img-element">3.1. Optionally-blockable Content</a> <a href="#ref-for-the-img-element①">(2)</a>
+    <li><a href="#ref-for-the-img-element">3.1. Upgradeable Content</a> <a href="#ref-for-the-img-element①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-parent-browsing-context">
@@ -1028,8 +966,7 @@ pre .property::before, pre .property::after {
    <ul>
     <li><a href="#ref-for-relevant-settings-object">4.3. 
       Does settings prohibit mixed security contexts? </a>
-    <li><a href="#ref-for-relevant-settings-object①">7. Modifications to WebSockets</a>
-    <li><a href="#ref-for-relevant-settings-object②">8.1. Form Submission</a>
+    <li><a href="#ref-for-relevant-settings-object①">7.1. Form Submission</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-responsible-document">
@@ -1042,7 +979,7 @@ pre .property::before, pre .property::after {
   <aside class="dfn-panel" data-for="term-for-the-source-element">
    <a href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-source-element">https://html.spec.whatwg.org/multipage/embedded-content.html#the-source-element</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-the-source-element">3.1. Optionally-blockable Content</a> <a href="#ref-for-the-source-element①">(2)</a>
+    <li><a href="#ref-for-the-source-element">3.1. Upgradeable Content</a> <a href="#ref-for-the-source-element①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-environment-target-browsing-context">
@@ -1061,25 +998,19 @@ pre .property::before, pre .property::after {
     <li><a href="#ref-for-top-level-browsing-context">3.2. Blockable Content</a>
     <li><a href="#ref-for-top-level-browsing-context①">4.3. 
       Does settings prohibit mixed security contexts? </a>
-    <li><a href="#ref-for-top-level-browsing-context②">8.1. Form Submission</a>
+    <li><a href="#ref-for-top-level-browsing-context②">7.1. Form Submission</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-use-srcset-or-picture">
    <a href="https://html.spec.whatwg.org/multipage/images.html#use-srcset-or-picture">https://html.spec.whatwg.org/multipage/images.html#use-srcset-or-picture</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-use-srcset-or-picture">3.1. Optionally-blockable Content</a>
+    <li><a href="#ref-for-use-srcset-or-picture">3.1. Upgradeable Content</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-video">
    <a href="https://html.spec.whatwg.org/multipage/media.html#video">https://html.spec.whatwg.org/multipage/media.html#video</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-video">3.1. Optionally-blockable Content</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-section-7.1.7">
-   <a href="https://tools.ietf.org/html/rfc6455#section-7.1.7">https://tools.ietf.org/html/rfc6455#section-7.1.7</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-section-7.1.7">7. Modifications to WebSockets</a> <a href="#ref-for-section-7.1.7①">(2)</a> <a href="#ref-for-section-7.1.7②">(3)</a>
+    <li><a href="#ref-for-video">3.1. Upgradeable Content</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-potentially-trustworthy-url">
@@ -1100,7 +1031,6 @@ pre .property::before, pre .property::after {
    <a href="https://xhr.spec.whatwg.org/#xmlhttprequest">https://xhr.spec.whatwg.org/#xmlhttprequest</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xmlhttprequest">3.2. Blockable Content</a>
-    <li><a href="#ref-for-xmlhttprequest①">7. Modifications to WebSockets</a>
    </ul>
   </aside>
   <h3 class="no-num no-ref heading settled" id="index-defined-elsewhere"><span class="content">Terms defined by reference</span><a class="self-link" href="#index-defined-elsewhere"></a></h3>
@@ -1123,7 +1053,6 @@ pre .property::before, pre .property::after {
     <ul>
      <li><span class="dfn-paneled" id="term-for-concept-request-client" style="color:initial">client</span>
      <li><span class="dfn-paneled" id="term-for-concept-request-destination" style="color:initial">destination</span>
-     <li><span class="dfn-paneled" id="term-for-dom-global-fetch" style="color:initial">fetch(input)</span>
      <li><span class="dfn-paneled" id="term-for-concept-response-https-state" style="color:initial">https state</span>
      <li><span class="dfn-paneled" id="term-for-concept-request-initiator" style="color:initial">initiator</span>
      <li><span class="dfn-paneled" id="term-for-concept-request-mode" style="color:initial">mode</span>
@@ -1136,8 +1065,6 @@ pre .property::before, pre .property::after {
    <li>
     <a data-link-type="biblio">[HTML]</a> defines the following terms:
     <ul>
-     <li><span class="dfn-paneled" id="term-for-eventsource" style="color:initial">EventSource</span>
-     <li><span class="dfn-paneled" id="term-for-websocket" style="color:initial">WebSocket</span>
      <li><span class="dfn-paneled" id="term-for-attr-fs-action" style="color:initial">action</span>
      <li><span class="dfn-paneled" id="term-for-active-document" style="color:initial">active document</span>
      <li><span class="dfn-paneled" id="term-for-audio" style="color:initial">audio</span>
@@ -1159,11 +1086,6 @@ pre .property::before, pre .property::after {
      <li><span class="dfn-paneled" id="term-for-top-level-browsing-context" style="color:initial">top-level browsing context</span>
      <li><span class="dfn-paneled" id="term-for-use-srcset-or-picture" style="color:initial">use srcset or picture</span>
      <li><span class="dfn-paneled" id="term-for-video" style="color:initial">video</span>
-    </ul>
-   <li>
-    <a data-link-type="biblio">[RFC6455]</a> defines the following terms:
-    <ul>
-     <li><span class="dfn-paneled" id="term-for-section-7.1.7" style="color:initial">fail the websocket connection</span>
     </ul>
    <li>
     <a data-link-type="biblio">[SECURE-CONTEXTS]</a> defines the following terms:
@@ -1194,16 +1116,10 @@ pre .property::before, pre .property::after {
    <dd>Mike West. <a href="https://www.w3.org/TR/mixed-content/">Mixed Content</a>. 2 August 2016. CR. URL: <a href="https://www.w3.org/TR/mixed-content/">https://www.w3.org/TR/mixed-content/</a>
    <dt id="biblio-rfc2119">[RFC2119]
    <dd>S. Bradner. <a href="https://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>. March 1997. Best Current Practice. URL: <a href="https://tools.ietf.org/html/rfc2119">https://tools.ietf.org/html/rfc2119</a>
-   <dt id="biblio-rfc6455">[RFC6455]
-   <dd>I. Fette; A. Melnikov. <a href="https://tools.ietf.org/html/rfc6455">The WebSocket Protocol</a>. December 2011. Proposed Standard. URL: <a href="https://tools.ietf.org/html/rfc6455">https://tools.ietf.org/html/rfc6455</a>
-   <dt id="biblio-rfc6797">[RFC6797]
-   <dd>J. Hodges; C. Jackson; A. Barth. <a href="https://tools.ietf.org/html/rfc6797">HTTP Strict Transport Security (HSTS)</a>. November 2012. Proposed Standard. URL: <a href="https://tools.ietf.org/html/rfc6797">https://tools.ietf.org/html/rfc6797</a>
    <dt id="biblio-secure-contexts">[SECURE-CONTEXTS]
    <dd>Mike West. <a href="https://www.w3.org/TR/secure-contexts/">Secure Contexts</a>. 15 September 2016. CR. URL: <a href="https://www.w3.org/TR/secure-contexts/">https://www.w3.org/TR/secure-contexts/</a>
    <dt id="biblio-url">[URL]
    <dd>Anne van Kesteren. <a href="https://url.spec.whatwg.org/">URL Standard</a>. Living Standard. URL: <a href="https://url.spec.whatwg.org/">https://url.spec.whatwg.org/</a>
-   <dt id="biblio-websockets">[WEBSOCKETS]
-   <dd>Ian Hickson. <a href="https://www.w3.org/TR/websockets/">The WebSocket API</a>. 20 September 2012. CR. URL: <a href="https://www.w3.org/TR/websockets/">https://www.w3.org/TR/websockets/</a>
    <dt id="biblio-xhr">[XHR]
    <dd>Anne van Kesteren. <a href="https://xhr.spec.whatwg.org/">XMLHttpRequest Standard</a>. Living Standard. URL: <a href="https://xhr.spec.whatwg.org/">https://xhr.spec.whatwg.org/</a>
   </dl>
@@ -1223,14 +1139,13 @@ pre .property::before, pre .property::after {
   <aside class="dfn-panel" data-for="mixed-content">
    <b><a href="#mixed-content">#mixed-content</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-mixed-content">3. Content Categories</a> <a href="#ref-for-mixed-content①">(2)</a>
-    <li><a href="#ref-for-mixed-content②">3.1. Optionally-blockable Content</a>
-    <li><a href="#ref-for-mixed-content③">4.4. 
+    <li><a href="#ref-for-mixed-content">3. Content Categories</a>
+    <li><a href="#ref-for-mixed-content①">3.1. Upgradeable Content</a>
+    <li><a href="#ref-for-mixed-content②">4.4. 
       Should fetching request be blocked as mixed content? </a>
-    <li><a href="#ref-for-mixed-content④">4.5. 
+    <li><a href="#ref-for-mixed-content③">4.5. 
       Should response to request be blocked as mixed
       content? </a>
-    <li><a href="#ref-for-mixed-content⑤">8.2. User Controls</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="a-priori-authenticated-url">
@@ -1242,7 +1157,7 @@ pre .property::before, pre .property::after {
     <li><a href="#ref-for-a-priori-authenticated-url③">4.4. 
       Should fetching request be blocked as mixed content? </a>
     <li><a href="#ref-for-a-priori-authenticated-url④">5.2. Modifications to HTML</a> <a href="#ref-for-a-priori-authenticated-url⑤">(2)</a> <a href="#ref-for-a-priori-authenticated-url⑥">(3)</a> <a href="#ref-for-a-priori-authenticated-url⑦">(4)</a>
-    <li><a href="#ref-for-a-priori-authenticated-url⑧">8.1. Form Submission</a> <a href="#ref-for-a-priori-authenticated-url⑨">(2)</a>
+    <li><a href="#ref-for-a-priori-authenticated-url⑧">7.1. Form Submission</a> <a href="#ref-for-a-priori-authenticated-url⑨">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="unauthenticated-response">
@@ -1261,12 +1176,12 @@ pre .property::before, pre .property::after {
       Does settings prohibit mixed security contexts? </a> <a href="#ref-for-embedding-document①">(2)</a> <a href="#ref-for-embedding-document②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="optionally-blockable-mixed-content">
-   <b><a href="#optionally-blockable-mixed-content">#optionally-blockable-mixed-content</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="upgradeable-mixed-content">
+   <b><a href="#upgradeable-mixed-content">#upgradeable-mixed-content</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-optionally-blockable-mixed-content">2. Key Concepts and Terminology</a>
-    <li><a href="#ref-for-optionally-blockable-mixed-content①">3.2. Blockable Content</a>
-    <li><a href="#ref-for-optionally-blockable-mixed-content②">8.2. User Controls</a> <a href="#ref-for-optionally-blockable-mixed-content③">(2)</a>
+    <li><a href="#ref-for-upgradeable-mixed-content">2. Key Concepts and Terminology</a>
+    <li><a href="#ref-for-upgradeable-mixed-content①">3.2. Blockable Content</a>
+    <li><a href="#ref-for-upgradeable-mixed-content②">7.2. User Controls</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="blockable-mixed-content">
@@ -1278,8 +1193,8 @@ pre .property::before, pre .property::after {
     <li><a href="#ref-for-blockable-mixed-content②">4.5. 
       Should response to request be blocked as mixed
       content? </a> <a href="#ref-for-blockable-mixed-content③">(2)</a>
-    <li><a href="#ref-for-blockable-mixed-content④">8.1. Form Submission</a>
-    <li><a href="#ref-for-blockable-mixed-content⑤">8.2. User Controls</a> <a href="#ref-for-blockable-mixed-content⑥">(2)</a>
+    <li><a href="#ref-for-blockable-mixed-content④">7.1. Form Submission</a>
+    <li><a href="#ref-for-blockable-mixed-content⑤">7.2. User Controls</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */

--- a/level2.src.html
+++ b/level2.src.html
@@ -27,6 +27,7 @@ Boilerplate: omit conformance, omit feedback-header
 <pre class="link-defaults">
 spec:html; type:dfn; for:/; text: use srcset or picture
 spec:html; type:dfn; for:/; text:browsing context
+spec:html; type:dfn; for:/; text:container document
 spec:html; type:dfn; for:/; text:plugin
 spec:html; type:dfn; for:/; text:global object
 spec:fetch; type:dfn; for:/; text:request
@@ -61,11 +62,11 @@ type: attribute
   cookie), or induce the user to take an unintended action (e.g., changing the
   label on a button). These requests are known as mixed content.
 
-  [[!MIXED-CONTENT]] details how a user agent can mitigate these risks by
+  [[!mixed-content]] details how a user agent can mitigate these risks by
   blocking certain types of mixed content, and behaving more strictly in some
   contexts.
 
-  However, as implemented in today's web browsers, [[!MIXED-CONTENT]] does not fully protect the
+  However, as implemented in today's web browsers, [[!mixed-content]] does not fully protect the
   confidentiality and integrity of users' data. Insecure content such as images, audio, and video
   can currently be loaded by default in secure contexts. Secure pages can even initiate insecure
   downloads which escape the user agent's sandbox entirely.
@@ -79,7 +80,7 @@ type: attribute
   transport or it isn't -- and encourage developers to securely load any mixed content that is
   necessary for their webpage to function properly.
 
-  Mixed Content Level 2 therefore updates and extends [[!MIXED-CONTENT]] to provide users with
+  Mixed Content Level 2 therefore updates and extends [[!mixed-content]] to provide users with
   better security and privacy guarantees and a better security UX, while minimizing
   breakage. Instead of advising browsers to simply strictly block all mixed content, the core idea
   of Level 2 is <i>mixed content autoupgrading</i>. That is, mixed content that user agents are not
@@ -104,7 +105,176 @@ type: attribute
 <section>
   <h2 id="terms">Key Concepts and Terminology</h2>
 
-  TODO
+  <dl>
+    <dt>
+      <dfn export local-lt="mixed">mixed content</dfn>
+    </dt>
+    <dd>
+      A <a>request</a> is <strong>mixed content</strong> if its
+      <a for="request">url</a> is not <a><i lang="la">a priori</i>
+      authenticated</a>, <strong>and</strong> the context responsible for
+      loading it requires prohibits mixed security contexts (see
+      [[#categorize-settings-object]] for a normative definition of the latter).
+
+      A <a>response</a> is <strong>mixed content</strong> if it is an
+      <a>unauthenticated response</a>, <strong>and</strong> the context
+      responsible for loading it requires prohibits mixed security contexts.
+
+      <div class="example">
+        Inside a context that restricts mixed content
+        (<code>https://secure.example.com/</code>, for example):
+
+        1.  A request for the script <code>http://example.com/script.js</code>
+            is <strong>mixed content</strong>. As script <a>requests</a> are
+            <a>blockable</a>, the user agent will return a network error rather
+            than loading the resource.
+
+        2.  A request for the image <code>http://example.com/image.png</code> is
+            <strong>mixed content</strong>. As image <a>requests</a> are
+            <a>optionally-blockable</a>, the user agent might load the image, in
+            which case the image resource itself would be <strong>mixed
+            content</strong>.
+      </div>
+
+      If mixed content is loaded into a context that restricts mixed content
+      (as in #2 above), that context is considered a <a>mixed security
+      context</a> (as defined in [[!RFC6797]]).
+
+      Note: "Mixed content" was originally defined in
+      <a href="https://www.w3.org/TR/wsc-ui/#securepage">section 5.3</a> of
+      [[WSC-UI]]. This document updates that initial definition.
+
+      Note: [[XML]] also defines an unrelated 
+      <a href="https://www.w3.org/TR/2008/REC-xml-20081126/#sec-mixed-content">"mixed content"</a>.
+      concept. This is potentially confusing, but given the term's near
+      ubiquitious usage in a security context across user agents for more than
+      a decade, the practical risk of confusion seems low.
+    </dd>
+
+    <dt>
+      <dfn export local-lt="a priori authenticated" oldids="a-priori-insecure-url a-priori-insecure-origin">
+        <i lang="la">a priori</i> authenticated URL
+      </dfn>
+    </dt>
+    <dd>
+      We know <i lang="la">a priori</i> that a request to a particular URL
+      (|url|) will be delivered in a way that mitigates the risks of
+      interception and modifications if either of the following statements is
+      true:
+
+      1.  |url| is a [=potentially trustworthy URL=] [[!SECURE-CONTEXTS]].
+
+      2.  |url|'s <a for="url">scheme</a> is "`data`".
+
+          Note: We special case `data` URLs here, as we don't consider them
+          particularly trustworthy, but we also don't wish to block them as
+          mixed content, as they never hit the network.
+    </dd>
+
+    <dt>
+      <dfn export local-lt="unauthenticated" oldids="insecure-origin insecure-url">
+        unauthenticated response
+      </dfn>
+    </dt>
+    <dd>
+      We know <i lang="la">a posteriori</i> that a <a>response</a>
+      (|response|) is unauthenticated if either of the following statements
+      is false:
+
+      1.  |response|'s <a for="response">url</a> is <a><i lang="la">a
+          priori</i> authenticated</a>.
+
+      2.  If |response|'s <a for="response">url</a>'s <a for="url">scheme</a>
+          is "`https`" or "`wss`", |response|'s <a for="response">HTTPS
+          state</a> is "`modern`".
+    </dd>
+
+    <dt><dfn export>embedding document</dfn></dt>
+    <dd>
+      Given a {{Document}} <var>A</var>, the <strong>embedding
+      document</strong> of <var>A</var> is |A|'s [=browsing context=]'s
+      [=container document=] [[!HTML]].
+    </dd>
+
+    <dt><dfn export>mixed download</dfn></dt>
+    <dd>
+      A mixed download is a resource that a user agent handles as a download,
+      which was initiated by a secure context but is downloaded over an
+      insecure connection.
+    </dd>
+  </dl>
+</section>
+
+<section>
+  <h2 id="categories">Content Categories</h2>
+
+  In a perfect world, each user agent would be required to block all <a>mixed
+  content</a> without exception. Unfortunately, that is impractical on today's
+  Internet; a user agent needs to be more nuanced in its restrictions to avoid
+  degrading the experience on a substantial number of websites.
+
+  With that in mind, we here split mixed content into two categories:
+  [[#category-optionally-blockable]] and [[#category-blockable]].
+
+  Note: Future versions of this specification will update this categorization
+  with the intent of moving towards a world where all <a>mixed</a> content is
+  blocked; that is the end goal, but this is the best we can do for now.
+
+  <section>
+    <h3 id="category-optionally-blockable">Optionally-blockable Content</h3>
+
+    Mixed content is
+    <dfn export lt="optionally-blockable mixed content" local-lt="optionally-blockable">optionally-blockable</dfn>
+    when the risk of allowing its usage as <a>mixed content</a> is outweighed by the risk of
+    breaking significant portions of the web. This could be because mixed usage of the resource type
+    is sufficiently high, and because the resource is low-risk in and of itself. The fact that these
+    resource types are optionally-blockable does not mean that they are <em>safe</em>, simply that
+    they're less catastrophically dangerous than other resource types. For example, images and icons
+    are often the central UI elements in an application's interface. If an attacker reversed the
+    "Delete email" and "Reply" icons, there would be real impact to users.
+
+    This category includes:
+
+    *   Requests whose [=request/initiator=] is the empty string, and whose [=request/destination=]
+        is "`image`".
+
+        Note: This corresponds to most images loaded via <{img}> (including SVG documents loaded as
+        images, as those are blocked from executing script or fetching subresources) and CSS
+        ('background-image', 'border-image', etc). It does not include <{img}> elements that [=use
+        srcset or picture=].
+
+    *   Requests whose [=request/destination=] is "`video`".
+
+        Note: This corresponds to video loaded via <{video}> and <{source}>.
+
+    *   Requests whose [=request/destination=] is "`audio`".
+
+        Note: This corresponds to audio loaded via <{audio}> and <{source}>.
+
+    We further limit this category in [[#should-block-fetch]] by force-failing any CORS-enabled
+    request. This means, for example, that mixed content images loaded via `<img crossorigin ...>`
+    will be blocked. This is a good example of the general principle that content falls into this
+    category <em>only</em> when it is too widely used to be blocked outright. The Working Group
+    intends to carve out more blockable subsets as time goes on.
+  </section>
+
+  <section>
+    <h3 id="category-blockable">Blockable Content</h3>
+
+    Any mixed content that is not [=optionally-blockable=] as defined above is considered to be
+    <dfn export lt="blockable mixed content" local-lt="blockable">blockable</dfn>. Typical examples
+    of this kind of content include scripts, <a>plugin</a> data, data requested via
+    {{XMLHttpRequest}}, and so on.
+
+    Note: <a>Navigation requests</a> might target <a>top-level browsing contexts</a>; these are not
+    considered mixed content. See [[#should-block-fetch]] for details.
+
+    Note: Note that requests made on behalf of a plugin are blockable. We recognize, however, that
+    user agents aren't always in a position to mediate these requests. NPAPI plugins, for instance,
+    often have direct network access, and can generally bypass the user agent entirely. We recommend
+    that user agents block these requests when possible, and that plugin vendors implement mixed
+    content checking themselves to mitigate the risks o utlined in this document.
+  </section>
 </section>
 
 <section>
@@ -127,10 +297,10 @@ type: attribute
         <ol>
           <li>
             <var>request</var>'s <a for="request">url</a> is an
-            [[mixed-content#a-priori-authenticated-url]].
+            <a><i lang="la">a priori</i> authenticated URLs</a>
           </li>
           <li>
-            [[mixed-content#categorize-settings-object]] returns "<code>Does Not Restrict Mixed Security
+            [[#categorize-settings-object]] returns "<code>Does Not Restrict Mixed Security
             Contents</code>" when applied to <var>request</var>'s <a for="request">client</a>.
           </li>
           <li>
@@ -161,19 +331,184 @@ type: attribute
   </section>
 
   <section>
-    <h3 id="modifications">Modifications to existing algorithms</h3>
+    <h3 id="existing-mix-algorithms">Existing Mixed Content Algorithms and Modifications</h3>
 
     Note: This section specifies modifications to existing mixed content algorithms to ignore the
     distinction between optionally-blockable and blockable mixed content, since all
     optionally-blockable mixed content will now be autoupgraded.
+    [[mixed-content#should-block-fetch]] and [[mixed-content#should-block-response]] are
+    replaced by the versions below, while [[mixed-content#categorize-settings-object]] is left
+    unmodified (but included below since this will replace the [[mixed-content]] spec). 
 
-    [[mixed-content#should-block-fetch]] should be modified to remove Steps 3, 4, and 5, replacing
-    them with a single step "Return <strong>blocked</strong>".
 
-    [[mixed-content#should-block-response]] should be modified to remove Steps 2, 3, and 4,
-    replacing them with a single step "Return <strong>blocked</strong>".
+    section>
+    <h3 id="categorize-settings-object">
+      Does |settings| prohibit mixed security contexts?
+    </h3>
+
+    Both documents and workers have [=environment settings objects=] which
+    may be examined according to the following algorithm in order to determine
+    whether they restrict mixed content. This algorithm returns "`Prohibits
+    Mixed Security Contexts`" or "`Does Not Prohibit Mixed Security Contexts`",
+    as appropriate.
+
+    Given an [=environment settings object=] (|settings|):
+    
+    1.  If |settings|' [=environment settings object/HTTPS state=] is not "`none`", then return
+        "`Prohibits Mixed Security Contexts`".
+
+    2.  If |settings| has a <a>responsible document</a> |document|, then:
+
+        1.  While |document| has an <a>embedding document</a>:
+
+            1.  Set |document| to |document|'s <a>embedding document</a>.
+
+            2.  Let |embedder settings| be |document|'s [=global object=]'s
+                [=relevant settings object=].
+
+            3.  If |embedder settings|' [=environment settings object/HTTPS state=] is not "`None`",
+                then return "`Prohibits Mixed Security Contexts`".
+
+    3.  Return "`Does Not Restrict Mixed Security Contexts`".
+
+    <div class="note">
+      If a document has an <a>embedding document</a>, a user agent needs to
+      check not only the document itself, but also the <a>top-level browsing
+      context</a> in which the document is nested, as that is the context
+      which controls the user's expectations regarding the security status of
+      the resource she's loaded. For example:
+
+      <div class="example">
+        <code>http://a.com</code> loads <code>http://evil.com</code>. The
+        insecure request will be allowed, as <code>a.com</code> was not loaded
+        over a secure connection.
+      </div>
+
+      <div class="example">
+        <code>https://a.com</code> loads <code>http://evil.com</code>. The
+        insecure request will be blocked, as <code>a.com</code> was loaded over
+        a secure connection.
+      </div>
+
+      <div class="example">
+        <code>http://a.com</code> frames <code>https://b.com</code>, which
+        loads <code>http://evil.com</code>. In this case, the insecure request
+        to <code>evil.com</code> will be blocked, as <code>b.com</code> was
+        loaded over a secure connection, even though <code>a.com</code> was not.
+      </div>
+
+      <div class="example">
+        <code>https://a.com</code> frames a <code>data:</code> URL, which loads
+        <code>http://evil.com</code>. In this case, the insecure request to
+        <code>evil.com</code> will be blocked, as <code>a.com</code> was loaded
+        over a secure connection, even though the framed <code>data:</code> URL
+        would not block mixed content if loaded in a top-level context.
+      </div>
+    </div>
+  </section>
+
+  <section>
+    <h3 id="should-block-fetch">
+      Should fetching <var>request</var> be blocked as mixed content?
+    </h3>
+
+    Note: The Fetch specification hooks into this algorithm to determine whether
+    a request should be entirely blocked (e.g. because the request is for
+    <a>blockable</a> content, and we can <em>assume</em> that it won't be
+    loaded over a secure connection).
+
+    Given a <a>Request</a> <var>request</var>, a user agent determines
+    whether the <a>Request</a> <var>request</var> should proceed or not via the
+    following algorithm:
+
+    <ol>
+      <li>
+        Return <strong>allowed</strong> if one or more of the following
+        conditions are met:
+
+        <ol>
+          <li>
+            [[#categorize-settings-object]] returns "`Does Not Restrict Mixed
+            Security Contexts`" when applied to |request|'s
+            <a for="request">client</a>.
+          </li>
+          <li>
+            |request|'s <a for="request">url</a> is <a><i lang="la">a priori</i>
+            authenticated</a>.
+          </li>
+          <li>
+            The user agent has been instructed to allow <a>mixed content</a>, as
+            described in [[#requirements-user-controls]]).
+          </li>
+          <li>
+            <var>request</var>'s <a for="request">destination</a> is
+            "<code>document</code>", and <var>request</var>'s <a>target browsing
+            context</a> has no <a>parent browsing context</a>.
+
+            Note: We exclude top-level navigations from mixed content checks,
+            but user agents MAY choose to enforce mixed content checks on
+            insecure form submissions (see [[#requirements-forms]]).
+          </li>
+        </ol>
+      </li>
+      <li>
+        Return <strong>blocked</strong>.
+      </li>
+    </ol>
+  </section>
+
+  <section>
+    <h3 id="should-block-response">
+      Should <var>response</var> to <var>request</var> be blocked as mixed
+      content?
+    </h3>
+
+    Note: <a href="#should-block-fetch">If a request proceeds</a>, we still
+    might want to block the response based on the state of the connection
+    that generated the response (e.g. because the request is <a>blockable</a>,
+    but the connection is <a>unauthenticated</a>), and we also need to ensure
+    that a Service Worker doesn't accidentally return an <a>unauthenticated
+    response</a> for a <a>blockable</a> request. This algorithm is used to make
+    that determination.
+
+    Given a <a>request</a> <var>request</var> and <a>response</a>
+    <var>response</var>, the user agent determines what response should be
+    returned via the following algorithm:
+
+    <ol>
+      <li>
+        Return <strong>allowed</strong> if one or more of the following
+        conditions are met:
+
+        <ol>
+          <li>
+            [[#categorize-settings-object]] returns <code>Does Not Restrict
+            Mixed Content</code> when applied to <var>request</var>'s
+            [=request/client=].
+          </li>
+          <li>
+            <var>response</var>'s [=response/HTTPS state=] is <code>modern</code>.
+          </li>
+          <li>
+            The user agent has been instructed to allow <a>mixed content</a>, as
+            described in [[#requirements-user-controls]]).
+          </li>
+          <li>
+            <var>request</var>'s <a for="request">destination</a> is
+            "<code>document</code>", and <var>request</var>'s <a>target browsing
+            context</a> has no <a>parent browsing context</a>.
+
+            Note: We exclude top-level navigations from mixed content checks,
+            but user agents MAY choose to enforce mixed content checks on
+            insecure form submissions (see [[#requirements-forms]]).
+          </li>
+        </ol>
+      </li>
+      <li>Return <strong>blocked</strong>.</li>
+    </ol>
+  </section>
+  </section>
 </section>
-
 <section>
   <h2 id="integration">Integrations</h2>
 
@@ -187,15 +522,15 @@ type: attribute
 
   <a>Process a navigate response</a> should be modified as follows. Step 3 should abort the download
   and return if <var>source</var>'s <a>active document</a>'s <a for="Document">url</a> is an
-  [[mixed-content#a-priori-authenticated-url]] and any URL
+  <a><i lang="la">a priori</i> authenticated URLs</a> and any URL
   in <var>response</var>'s <a for="response">URL list</a> is not an
-  [[mixed-content#a-priori-authenticated-url]].
+  <a><i lang="la">a priori</i> authenticated URLs</a>.
 
   A similar change should be made to <a>downloads a hyperlink</a>. In this algorithm, step 6.2
   should be modified to return (aborting the download) if <var>subject</var>'s <a>node
-  document</a>'s <a for="Document">url</a> is an [[mixed-content#a-priori-authenticated-url]] and
+  document</a>'s <a for="Document">url</a> is an <a><i lang="la">a priori</i> authenticated URLs</a> and
   any URL in <var>response</var>'s <a for="response">URL list</a> is not an
-  [[mixed-content#a-priori-authenticated-url]] (where <var>response</var> is the result of
+  <a><i lang="la">a priori</i> authenticated URLs</a> (where <var>response</var> is the result of
   fetching <var>request</var>).
 
   Note: Downloads are not autoupgraded like other types of mixed content, because the user agent
@@ -220,6 +555,57 @@ type: attribute
   Note: The <code>upgrade-insecure-requests</code> ([[upgrade-insecure-requests]]) directive is not
   obsolete because it allows developers to upgrade blockable content. This specification only
   upgrades optionally-blockable content by default.
+
+  <h3 id="mixed-content-1"><code>Mixed Content</code></h3>
+
+  This specification renders the [[mixed-content]] specification obsolete,
+  and replaces it.
+</section>
+
+<section>
+  <h2 id="websockets-integration">Modifications to WebSockets</h2>
+
+  The <a href="https://www.w3.org/TR/websockets/#the-websocket-interface"><code>WebSocket()</code>
+  constructor algorithm</a> [[!WEBSOCKETS]] is modified as follows:
+
+  <ul>
+    <li>
+      Remove the current step 2.
+    </li>
+  </ul>
+
+  Note: This suggestion is filed as
+  <a href="https://www.w3.org/Bugs/Public/show_bug.cgi?id=28841">bug #28841</a>
+  against [[WEBSOCKETS]].
+
+  The <a href="http://tools.ietf.org/html/rfc6455#section-4.1">Establish a
+  WebSocket Connection algorithm</a> [[!RFC6455]] is modified as follows:
+
+  1.  After the current step 1, perform the following step:
+
+      1.  If |secure| is `false`, and the algorithm in
+          [[#categorize-settings-object]] returns "`Restricts Mixed Security
+          Context`" when applied to <var ignore>client</var>'s <a>global object</a>'s
+          <a>relevant settings object</a>, then the client MUST <a>fail the
+          WebSocket connection</a> and abort the connection [[!RFC6455]].
+
+  2.  After the current step 5, perform the following step:
+
+      6.  If |secure| is `true`, and the TLS handshake performed in step 5
+          results in an HTTPS state of "`deprecated`", then the client MUST
+          <a>fail the WebSocket connection</a> and abort the connection
+          [[!RFC6455]].
+
+  Note: Filed as
+  <a href="http://www.rfc-editor.org/errata_search.php?rfc=6455&eid=4398">errata #4398</a>
+  against [[RFC6455]].
+
+  These changes together mean that we'll no longer throw a `SecurityError`
+  exception directly upon constructing a WebSocket object, but will instead rely
+  upon blocking the connection and triggering the <a>fail the WebSocket
+  connection</a> algorithm, which developers can catch by hooking a
+  {{WebSocket}} object's {{WebSocket/onerror}} handler. This is consistent with
+  the behavior of {{XMLHttpRequest}}, {{EventSource}}, and {{fetch()}}.
 </section>
 
 <section>
@@ -237,7 +623,52 @@ type: attribute
   autoupgrading only optionally-blockable content, not blockable content as well. Blockable content
   could present more risk, for example the risk of loading an out-of-date and vulnerable JavaScript
   library.
+
+  <section>
+    <h3 id="requirements-forms">Form Submission</h3>
+
+    If [[#categorize-settings-object]] returns `Restricts Mixed Content` when applied to a
+    {{Document}}'s [=relevant settings object=], then a user agent MAY choose to warn users of the
+    presence of one or more <{form}> elements with <a element-attr>action</a> attributes whose
+    values are not <a><i lang="la">a priori</i> authenticated URLs</a>
+
+    A user agent MAY choose to warn users on submission of a <{form}> element with 
+    <a element-attr>action</a> attributes whose values are not <a><i lang="la">a priori</i>
+    authenticated URLs</a> and allow users to abort the submission.
+
+    Further, a user agent MAY treat form submissions from such a {{Document}} as a [=blockable=]
+    request, even if the submission occurs in the [=top-level browsing context=].
+  </section>
 </section>
+
+<section>
+    <h3 id="requirements-user-controls">User Controls</h3>
+
+    A user agent MAY offer users the ability to directly decide whether or not
+    to treat <strong>all</strong> <a>mixed content</a> as <a>blockable</a>
+    (meaning that even <a>optionally-blockable</a> mixed content would be
+    blocked).
+
+    Note: It is <em>strongly recommended</em> that users take advantage of such
+    an option if provided.
+
+    A user agent MAY offer users the ability to override its decision to block
+    <a>blockable</a> mixed content on a particular page.
+
+    Note: Practically, a user agent probably can't get away with not offering
+    such a back door. That said, allowing mixed script is in particular a very
+    dangerous option, and each user agent
+    <a href="http://tools.ietf.org/html/rfc6919#section-3">REALLY SHOULD NOT</a>
+    [[RFC6919]] present such a choice to users without careful consideration and
+    communication of the risk involved.
+
+    A user agent MAY offer users the ability to override its decision to
+    automatically upgrade <a>optionally-blockable</a> mixed content on a
+    particular page.
+
+    Any such controls offered by a user agent MUST also be offered through
+    accessibility APIs for users of assistive technologies.
+  </section>
 
 <section>
   <h2 id="acknowledgements">Acknowledgements</h2>

--- a/level2.src.html
+++ b/level2.src.html
@@ -612,4 +612,12 @@ type: attribute
 
 <section>
   <h2 id="acknowledgements">Acknowledgements</h2>
+
+  In addition to the wonderful feedback gathered from the WebAppSec WG, the
+  Chrome security team was invaluable in preparing this specification. In
+  particular, Chris Palmer, Chris Evans, Ryan Sleevi, Michal Zalewski, Ken
+  Buchanan, and Tom Sepez gave lots of early feedback. Anne van Kesteren
+  explained Fetch, helped define the interface to this specification,
+  and provided valuable feedback on the Level 2 update.
+  Brian Smith helped keep the spec focused, trim, and sane.
 </section>

--- a/level2.src.html
+++ b/level2.src.html
@@ -131,14 +131,10 @@ type: attribute
 
         2.  A request for the image <code>http://example.com/image.png</code> is
             <strong>mixed content</strong>. As image <a>requests</a> are
-            <a>optionally-blockable</a>, the user agent might load the image, in
-            which case the image resource itself would be <strong>mixed
-            content</strong>.
+            <a>upgradeable</a>, the user agent might rewrite the URL as
+            <code>http://example.com/image.png</code>, otherwise it will block
+            the load.
       </div>
-
-      If mixed content is loaded into a context that restricts mixed content
-      (as in #2 above), that context is considered a <a>mixed security
-      context</a> (as defined in [[!RFC6797]]).
 
       Note: "Mixed content" was originally defined in
       <a href="https://www.w3.org/TR/wsc-ui/#securepage">section 5.3</a> of
@@ -214,21 +210,20 @@ type: attribute
   degrading the experience on a substantial number of websites.
 
   With that in mind, we here split mixed content into two categories:
-  [[#category-optionally-blockable]] and [[#category-blockable]].
-
-  Note: Future versions of this specification will update this categorization
-  with the intent of moving towards a world where all <a>mixed</a> content is
-  blocked; that is the end goal, but this is the best we can do for now.
+  [[#category-upgradeable]] and [[#category-blockable]].
 
   <section>
-    <h3 id="category-optionally-blockable">Optionally-blockable Content</h3>
+    <h3 id="category-upgradeable">Upgradeable Content</h3>
+
+    <note>Upgradeable content was previously referred as optionally-blockable in
+    [[mixed-content]]</note>
 
     Mixed content is
-    <dfn export lt="optionally-blockable mixed content" local-lt="optionally-blockable">optionally-blockable</dfn>
+    <dfn export lt="upgradeable mixed content" local-lt="upgradeable">upgradeable</dfn>
     when the risk of allowing its usage as <a>mixed content</a> is outweighed by the risk of
     breaking significant portions of the web. This could be because mixed usage of the resource type
     is sufficiently high, and because the resource is low-risk in and of itself. The fact that these
-    resource types are optionally-blockable does not mean that they are <em>safe</em>, simply that
+    resource types are upgradeable does not mean that they are <em>safe</em>, simply that
     they're less catastrophically dangerous than other resource types. For example, images and icons
     are often the central UI elements in an application's interface. If an attacker reversed the
     "Delete email" and "Reply" icons, there would be real impact to users.
@@ -261,7 +256,7 @@ type: attribute
   <section>
     <h3 id="category-blockable">Blockable Content</h3>
 
-    Any mixed content that is not [=optionally-blockable=] as defined above is considered to be
+    Any mixed content that is not [=upgradeable=] as defined above is considered to be
     <dfn export lt="blockable mixed content" local-lt="blockable">blockable</dfn>. Typical examples
     of this kind of content include scripts, <a>plugin</a> data, data requested via
     {{XMLHttpRequest}}, and so on.
@@ -273,7 +268,7 @@ type: attribute
     user agents aren't always in a position to mediate these requests. NPAPI plugins, for instance,
     often have direct network access, and can generally bypass the user agent entirely. We recommend
     that user agents block these requests when possible, and that plugin vendors implement mixed
-    content checking themselves to mitigate the risks o utlined in this document.
+    content checking themselves to mitigate the risks outlined in this document.
   </section>
 </section>
 
@@ -284,11 +279,11 @@ type: attribute
     <h3 id="upgrade-algorithm">Upgrade |request| to an <i lang="la">a priori</i>
     authenticated URL as mixed content, if appropriate</h3>
 
-    Note: The Fetch specification will hook into this algorithm to upgrade optionally-blockable
+    Note: The Fetch specification will hook into this algorithm to upgrade upgradeable
     mixed content to HTTPS.
 
     Given a <a>Request</a> <var>request</var>, this algorithm will rewrite
-    its <a for="request">url</a> if the request is deemed to be optionally-blockable mixed content,
+    its <a for="request">url</a> if the request is deemed to be upgradeable mixed content,
     via the following algorithm:
 
     <ol>
@@ -297,7 +292,7 @@ type: attribute
         <ol>
           <li>
             <var>request</var>'s <a for="request">url</a> is an
-            <a><i lang="la">a priori</i> authenticated URLs</a>
+            <a><i lang="la">a priori</i> authenticated URL</a>
           </li>
           <li>
             [[#categorize-settings-object]] returns "<code>Does Not Restrict Mixed Security
@@ -515,7 +510,7 @@ type: attribute
   <h3 id="fetch">Modifications to Fetch</h3>
 
   [[fetch#main-fetch]] should be modified to call [[#upgrade-algorithm]] on <var>request</var>
-  between steps 3 and 4. That is, optionally-blockable mixed content should be autoupgraded to HTTPS
+  between steps 3 and 4. That is, upgradeable mixed content should be autoupgraded to HTTPS
   before applying mixed content blocking.
 
   <h3 id="html">Modifications to HTML</h3>
@@ -554,7 +549,7 @@ type: attribute
 
   Note: The <code>upgrade-insecure-requests</code> ([[upgrade-insecure-requests]]) directive is not
   obsolete because it allows developers to upgrade blockable content. This specification only
-  upgrades optionally-blockable content by default.
+  upgrades upgradeable content by default.
 
   <h3 id="mixed-content-1"><code>Mixed Content</code></h3>
 
@@ -563,55 +558,9 @@ type: attribute
 </section>
 
 <section>
-  <h2 id="websockets-integration">Modifications to WebSockets</h2>
-
-  The <a href="https://www.w3.org/TR/websockets/#the-websocket-interface"><code>WebSocket()</code>
-  constructor algorithm</a> [[!WEBSOCKETS]] is modified as follows:
-
-  <ul>
-    <li>
-      Remove the current step 2.
-    </li>
-  </ul>
-
-  Note: This suggestion is filed as
-  <a href="https://www.w3.org/Bugs/Public/show_bug.cgi?id=28841">bug #28841</a>
-  against [[WEBSOCKETS]].
-
-  The <a href="http://tools.ietf.org/html/rfc6455#section-4.1">Establish a
-  WebSocket Connection algorithm</a> [[!RFC6455]] is modified as follows:
-
-  1.  After the current step 1, perform the following step:
-
-      1.  If |secure| is `false`, and the algorithm in
-          [[#categorize-settings-object]] returns "`Restricts Mixed Security
-          Context`" when applied to <var ignore>client</var>'s <a>global object</a>'s
-          <a>relevant settings object</a>, then the client MUST <a>fail the
-          WebSocket connection</a> and abort the connection [[!RFC6455]].
-
-  2.  After the current step 5, perform the following step:
-
-      6.  If |secure| is `true`, and the TLS handshake performed in step 5
-          results in an HTTPS state of "`deprecated`", then the client MUST
-          <a>fail the WebSocket connection</a> and abort the connection
-          [[!RFC6455]].
-
-  Note: Filed as
-  <a href="http://www.rfc-editor.org/errata_search.php?rfc=6455&eid=4398">errata #4398</a>
-  against [[RFC6455]].
-
-  These changes together mean that we'll no longer throw a `SecurityError`
-  exception directly upon constructing a WebSocket object, but will instead rely
-  upon blocking the connection and triggering the <a>fail the WebSocket
-  connection</a> algorithm, which developers can catch by hooking a
-  {{WebSocket}} object's {{WebSocket/onerror}} handler. This is consistent with
-  the behavior of {{XMLHttpRequest}}, {{EventSource}}, and {{fetch()}}.
-</section>
-
-<section>
   <h2 id="security-considerations">Security and Privacy Considerations</h2>
 
-  Overall, autoupgrading optionally-blockable mixed content is expected to be security- and
+  Overall, autoupgrading upgradeable mixed content is expected to be security- and
   privacy-positive, by protecting more user traffic from network eavesdropping and tampering.
 
   There is a risk of introducing a security or privacy issue in a webpage by loading a resource that
@@ -620,7 +569,7 @@ type: attribute
   reason <code>https://www.example.com/image.jpg</code> redirects to a tracking site. The browser
   will now have introduced a privacy issue without the developer's or user's explicit
   consent. However, these cases are expected to be exceedingly rare. The risk is mitigated by
-  autoupgrading only optionally-blockable content, not blockable content as well. Blockable content
+  autoupgrading only upgradeable content, not blockable content as well. Blockable content
   could present more risk, for example the risk of loading an out-of-date and vulnerable JavaScript
   library.
 
@@ -643,15 +592,6 @@ type: attribute
 
 <section>
     <h3 id="requirements-user-controls">User Controls</h3>
-
-    A user agent MAY offer users the ability to directly decide whether or not
-    to treat <strong>all</strong> <a>mixed content</a> as <a>blockable</a>
-    (meaning that even <a>optionally-blockable</a> mixed content would be
-    blocked).
-
-    Note: It is <em>strongly recommended</em> that users take advantage of such
-    an option if provided.
-
     A user agent MAY offer users the ability to override its decision to block
     <a>blockable</a> mixed content on a particular page.
 
@@ -663,7 +603,7 @@ type: attribute
     communication of the risk involved.
 
     A user agent MAY offer users the ability to override its decision to
-    automatically upgrade <a>optionally-blockable</a> mixed content on a
+    automatically upgrade <a>upgradeable</a> mixed content on a
     particular page.
 
     Any such controls offered by a user agent MUST also be offered through


### PR DESCRIPTION
This incorporates the suggestions in https://github.com/w3c/webappsec-mixed-content/issues/25 to merge MIX onto MIX2, so MIX2 can completely replace it.