### PR TITLE
Fix typo: upgrade should turn scheme into https

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -133,7 +133,7 @@ type: attribute
         2.  A request for the image <code>http://example.com/image.png</code> is
             <strong>mixed content</strong>. As image <a>requests</a> are
             <a>upgradeable</a>, the user agent might rewrite the URL as
-            <code>http://example.com/image.png</code>, otherwise it will block
+            <code>https://example.com/image.png</code>, otherwise it will block
             the load.
       </div>
 


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/bokand/webappsec-mixed-content/pull/37.html" title="Last updated on Feb 16, 2021, 11:22 PM UTC (3f6a231)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-mixed-content/37/dd97234...bokand:3f6a231.html" title="Last updated on Feb 16, 2021, 11:22 PM UTC (3f6a231)">Diff</a>