### PR TITLE
Editorial: several fields are now called URL (uppercase)

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -30,7 +30,6 @@ spec:html; type:dfn; for:/; text: use srcset or picture
 spec:html; type:dfn; for:/; text:browsing context
 spec:html; type:dfn; for:/; text:container document
 spec:html; type:dfn; for:/; text:plugin
-spec:html; type:dfn; for:/; text:global object
 spec:fetch; type:dfn; for:/; text:request
 spec:fetch; type:dfn; for:/; text:response
 spec:dom; type:interface; text:Document
@@ -112,7 +111,7 @@ type: attribute
     </dt>
     <dd>
       A <a>request</a> is <strong>mixed content</strong> if its
-      <a for="request">url</a> is not a [=potentially trustworthy URL=] [[!SECURE-CONTEXTS]]
+      <a for="request">URL</a> is not a [=potentially trustworthy URL=] [[!SECURE-CONTEXTS]]
       <strong>and</strong> the context responsible for
       loading it prohibits mixed security contexts (see
       [[#categorize-settings-object]] for a normative definition of the latter).
@@ -141,7 +140,7 @@ type: attribute
       <a href="https://www.w3.org/TR/wsc-ui/#securepage">section 5.3</a> of
       [[WSC-UI]]. This document updates that initial definition.
 
-      Note: [[XML]] also defines an unrelated 
+      Note: [[XML]] also defines an unrelated
       <a href="https://www.w3.org/TR/2008/REC-xml-20081126/#sec-mixed-content">"mixed content"</a>.
       concept. This is potentially confusing, but given the term's near
       ubiquitious usage in a security context across user agents for more than
@@ -156,7 +155,7 @@ type: attribute
     <dd>
       We know <i lang="la">a posteriori</i> that a <a>response</a>
       (|response|) is unauthenticated if |response|'s
-      <a for="response">url</a> is not a [=potentially trustworthy URL=].
+      <a for="response">URL</a> is not a [=potentially trustworthy URL=].
     </dd>
 
     <dt><dfn export>embedding document</dfn></dt>
@@ -253,13 +252,13 @@ type: attribute
   <h2 id="algorithms">Algorithms</h2>
 
   <section>
-    <h3 id="upgrade-algorithm">Upgrade a mixed content |request| to a [=potentially trustworthy URL=], if appropriate</h3>
+    <h3 export dfn id="upgrade-algorithm">Upgrade a mixed content |request| to a [=potentially trustworthy URL=], if appropriate</h3>
 
     Note: The Fetch specification will hook into this algorithm to upgrade upgradeable
     mixed content to HTTPS.
 
     Given a <a>Request</a> <var>request</var>, this algorithm will rewrite
-    its <a for="request">url</a> if the request is deemed to be upgradeable mixed content,
+    its <a for="request">URL</a> if the request is deemed to be upgradeable mixed content,
     via the following algorithm:
 
     <ol>
@@ -267,7 +266,7 @@ type: attribute
         If one or more of the following conditions is met, return without modifying <var>request</var>:
         <ol>
           <li>
-            <var>request</var>'s <a for="request">url</a> is a
+            <var>request</var>'s <a for="request">URL</a> is a
             [=potentially trustworthy URL=].
           </li>
           <li>
@@ -288,9 +287,9 @@ type: attribute
         </ol>
       </li>
       <li>
-        If <var>request</var>'s <a for="request">url</a>'s <a for="url">scheme</a>
+        If <var>request</var>'s <a for="request">URL</a>'s <a for="url">scheme</a>
         is <code>http</code>,
-        set <var>request</var>'s <a for="request">url</a>'s <a for="url">scheme</a>
+        set <var>request</var>'s <a for="request">URL</a>'s <a for="url">scheme</a>
         to <code>https</code>, and return.
 
         Note: Per [[url]], we do not modify the port because it will be set to null when the scheme
@@ -309,7 +308,7 @@ type: attribute
     optionally-blockable mixed content will now be autoupgraded.
     [[mixed-content#should-block-fetch]] and [[mixed-content#should-block-response]] are
     replaced by the versions below, while [[mixed-content#categorize-settings-object]] is left
-    unmodified (but included below since this will replace the [[mixed-content]] spec). 
+    unmodified (but included below since this will replace the [[mixed-content]] spec).
 
 
     section>
@@ -324,7 +323,7 @@ type: attribute
     as appropriate.
 
     Given an [=environment settings object=] (|settings|):
-    
+
     1.  If |settings|' [=environment settings object/origin=] is a
         [=potentially trustworthy origin=], then return
         "`Prohibits Mixed Security Contexts`".
@@ -335,8 +334,7 @@ type: attribute
 
             1.  Set |document| to |document|'s <a>embedding document</a>.
 
-            2.  Let |embedder settings| be |document|'s [=global object=]'s
-                [=relevant settings object=].
+            2.  Let |embedder settings| be |document|'s [=relevant settings object=].
 
             3.  If |embedder settings|'
                 [=environment settings object/origin=] is a
@@ -382,7 +380,7 @@ type: attribute
   </section>
 
   <section>
-    <h3 id="should-block-fetch">
+    <h3 export dfn id="should-block-fetch">
       Should fetching <var>request</var> be blocked as mixed content?
     </h3>
 
@@ -407,7 +405,7 @@ type: attribute
             <a for="request">client</a>.
           </li>
           <li>
-            |request|'s <a for="request">url</a> is a [=potentially trustworthy URL=].
+            |request|'s <a for="request">URL</a> is a [=potentially trustworthy URL=].
           </li>
           <li>
             The user agent has been instructed to allow <a>mixed content</a>, as
@@ -431,7 +429,7 @@ type: attribute
   </section>
 
   <section>
-    <h3 id="should-block-response">
+    <h3 export dfn id="should-block-response">
       Should <var>response</var> to <var>request</var> be blocked as mixed
       content?
     </h3>
@@ -494,14 +492,14 @@ type: attribute
   <h3 id="html">Modifications to HTML</h3>
 
   <a>Process a navigate response</a> should be modified as follows. Step 3 should abort the download
-  and return if <var>source</var>'s <a>active document</a>'s <a for="Document">url</a> is a
+  and return if <var ignore>source</var>'s <a>active document</a>'s <a for="Document">URL</a> is a
   [=potentially trustworthy URL=] and any URL
   in <var>response</var>'s <a for="response">URL list</a> is not a
   [=potentially trustworthy URL=].
 
-  A similar change should be made to <a>downloads a hyperlink</a>. In this algorithm, step 6.2
-  should be modified to return (aborting the download) if <var>subject</var>'s <a>node
-  document</a>'s <a for="Document">url</a> is a [=potentially trustworthy URL=] and
+  A similar change should be made to <a>download the hyperlink</a>. In this algorithm, step 6.2
+  should be modified to return (aborting the download) if <var ignore>subject</var>'s <a>node
+  document</a>'s <a for="Document">URL</a> is a [=potentially trustworthy URL=] and
   any URL in <var>response</var>'s <a for="response">URL list</a> is not a
   [=potentially trustworthy URL=] (where <var>response</var> is the result of
   fetching <var>request</var>).
@@ -560,7 +558,7 @@ type: attribute
     presence of one or more <{form}> elements with <a element-attr>action</a> attributes whose
     values are not [=potentially trustworthy URL=]s.
 
-    A user agent MAY choose to warn users on submission of a <{form}> element with 
+    A user agent MAY choose to warn users on submission of a <{form}> element with
     <a element-attr>action</a> attributes whose values are not [=potentially trustworthy URL=]s
     and allow users to abort the submission.
 


### PR DESCRIPTION
Also export three definitions for Fetch and correct a couple of Bikeshed issues.

(@domenic this was using the downloads a hyperlink xref too... Hopefully there's not a lot more.)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-mixed-content/pull/43.html" title="Last updated on Mar 11, 2021, 2:14 PM UTC (0b7ad3f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-mixed-content/43/6ebd2cf...0b7ad3f.html" title="Last updated on Mar 11, 2021, 2:14 PM UTC (0b7ad3f)">Diff</a>