### PR TITLE
Remove TR reference from MIX2

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -556,7 +556,10 @@ type: dfn
 
     A user agent MAY choose to warn users on submission of a <{form}> element with
     <a element-attr>action</a> attributes whose values are not [=potentially trustworthy URL=]s
-    and allow users to abort the submission.
+    and allow users to abort the submission. If a user agent warns on <{form}> element
+    submissions to not [=potentially trustworthy URL=]s, it SHOULD also warn and allow users to
+    abort the submission if upon submission, the <{form}> element's action, redirects to a
+    non [=potentially trustworthy URL=], exposing the <{form}> information.
 
     Further, a user agent MAY treat form submissions from such a {{Document}} as a [=blockable=]
     request, even if the submission occurs in the [=top-level browsing context=].

--- a/index.bs
+++ b/index.bs
@@ -2,7 +2,6 @@
 <pre class="metadata">
 Status: ED
 ED: https://w3c.github.io/webappsec-mixed-content/
-TR: https://www.w3.org/TR/mixed-content-2/
 Shortname: mixed-content-2
 Level: 2
 Editor: Emily Stark, Google Inc., estark@google.com


### PR DESCRIPTION
As mentioned in #25, the "Last Published Version" link in MIX2 currently leads to a 404, since there is none (as MIX2 is still only an Editor's Draft). This removes the link, which we can re-add once MIX2 moves to FPWD and there is a published version to point to.