### PR TITLE
Remove CORS exception for upgrade algorithm [FIXES: #63]

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -276,9 +276,6 @@ type: dfn
             Contents</code>" when applied to <var>request</var>'s <a for="request">client</a>.
           </li>
           <li>
-            <var>request</var>'s <a for="request">mode</a> is <code>CORS</code>.
-          </li>
-          <li>
             <var>request</var>'s <a for="request">destination</a> is not "<code>image</code>",
             "<code>audio</code>", or "<code>video</code>".
           </li>


### PR DESCRIPTION
As mentioned in https://github.com/w3c/webappsec-mixed-content/issues/63#issuecomment-1386714463.  It might be worth to update the spec's upgrading algorithm. Because exempting CORS requests could lead to insecure loads via HTTP. 

Also, if we were blocking CORS request we wouldn't break any CORS request with trying to autoupgrade it.